### PR TITLE
Ability to disable PGP support

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -742,6 +742,10 @@ public class ConversationFragment extends Fragment {
 					});
 		}
 	}
+	
+	public RelativeLayout getSnackbar() {
+		return snackbar;
+	}
 
 	protected void showSnackbar(int message, int action,
 			OnClickListener clickListener) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -252,6 +252,8 @@
     <string name="pref_dont_save_encrypted_summary">Warning: This could lead to message loss</string>
     <string name="pref_enable_legacy_ssl">Enable legacy SSL</string>
     <string name="pref_enable_legacy_ssl_summary">Enables SSLv3 support for legacy servers. Warning: SSLv3 is considered insecure.</string>
+    <string name="pref_disable_pgp">Disable PGP</string>
+    <string name="pref_disable_pgp_summary">Disable support for PGP encryption</string>
     <string name="pref_expert_options">Expert options</string>
     <string name="pref_expert_options_summary">Please be careful with these</string>
     <string name="pref_use_larger_font">Increase font size</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -91,6 +91,11 @@
                     android:title="@string/pref_dont_save_encrypted" />
                 <CheckBoxPreference
                     android:defaultValue="false"
+                    android:key="disable_pgp"
+                    android:summary="@string/pref_disable_pgp_summary"
+                    android:title="@string/pref_disable_pgp" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
                     android:key="enable_legacy_ssl"
                     android:summary="@string/pref_enable_legacy_ssl_summary"
                     android:title="@string/pref_enable_legacy_ssl" />


### PR DESCRIPTION
An option to hide PGP support for conversations to simplify user experience.

If 'force end-to-end encryption' option is set as well (and the conversation is encrypted), clicking on the lock icon will display the OTR fingerprints for the selected conversation