### PR TITLE
Add materials theme for v21 devices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ android:
   components:
     - platform-tools
     - tools
+    - build-tools-21.1.2
     - build-tools-19.1.0
-    - android-19
+    - android-21

--- a/build.gradle
+++ b/build.gradle
@@ -40,12 +40,12 @@ dependencies {
 }
 
 android {
-	compileSdkVersion 19
-	buildToolsVersion "19.1"
+	compileSdkVersion 21
+	buildToolsVersion "21.1.2"
 
 	defaultConfig {
 		minSdkVersion 14
-		targetSdkVersion 19
+		targetSdkVersion 21
 		versionCode 41
 		versionName "0.10"
 	}

--- a/src/main/res/values-v21/themes.xml
+++ b/src/main/res/values-v21/themes.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ConversationsTheme" parent="@android:style/Theme.Material.Light.DarkActionBar">
+        <item name="android:colorPrimary">@color/primary</item>
+        <item name="android:colorPrimaryDark">@color/primarydark</item>
+        <item name="android:colorAccent">@color/accent</item>
+
+        <item name="TextSizeInfo">12sp</item>
+        <item name="TextSizeBody">14sp</item>
+        <item name="TextSizeHeadline">20sp</item>
+    </style>
+
+</resources>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
 
     <color name="primary" type="color">#ff259b24</color>
     <color name="primarydark" type="color">#ff0a7e07</color>
+    <color name="accent">#ff0091ea</color>
     <color name="primarytext" type="color">#de000000</color>
     <color name="secondarytext" type="color">#8a000000</color>
     <color name="ondarktext" type="color">#fffafafa</color>


### PR DESCRIPTION
Adds some elements of the materials theme for v21 devices. This does not use `appcompat` as @iNPUTmice mentioned that he did not want to maintain a compatibility mode in the conference earlier. Instead, it is a separate theme that is only loaded on v21 devices. This also required updating the target SDK in the build script (otherwise the status bar isn't handled properly).

The status bar color is set to `colorPrimaryDark` as per the material guidelines:

![screenshot](https://cloud.githubusercontent.com/assets/512573/5640021/e80ad0aa-95ed-11e4-9210-de2207b307a6.png)

I semi-arbitrarily picked an accent color from the Light blue [pallet](http://www.google.com/design/spec/style/color.html#color-color-palette) that can be found in the Google design giudelines. A700 `#ff0091ea`, but that can be changed easily if desired.
 
![screenshot2](https://cloud.githubusercontent.com/assets/512573/5640166/fdc39182-95ef-11e4-8eb0-bab2675bd228.png)

The action bar is also the correct color in the open apps menu (before it looked like Firefox does in the screen cap):

![screenshot_2015-01-06-22-36-19](https://cloud.githubusercontent.com/assets/512573/5640546/cb1dbd0c-95f4-11e4-90e5-a9c3fda634fa.png)

