### PR TITLE
Don't fail on extra translations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ android {
 	}
 
 	lintOptions {
-		disable 'MissingTranslation', 'InvalidPackage'
+		disable 'ExtraTranslation', 'MissingTranslation', 'InvalidPackage'
 	}
 
 	subprojects {


### PR DESCRIPTION
Now that Transifex is being used, we shouldn't fail the build on extra translations since it will handle this for us the next time translations are generated / imported. Downgrade them to a warning as far as the linter is concerned.