### PR TITLE
Add an option to enable pebble notifications

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -136,8 +136,9 @@ public class NotificationService {
 			final boolean doNotify = (!(this.mIsInForeground && this.mOpenConversation == null) || !isScreenOn)
 					&& !account.inGracePeriod()
 					&& !this.inMiniGracePeriod(account);
+			final boolean pebble = mXmppConnectionService.getPreferences().getBoolean("pebble_notification", false);
 			updateNotification(doNotify);
-			if (doNotify) {
+			if (doNotify && pebble) {
 				notifyPebble(message);
 			}
 		}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -111,6 +111,8 @@
     <string name="pref_notifications_summary">Notify when a new message arrives</string>
     <string name="pref_vibrate">Vibrate</string>
     <string name="pref_vibrate_summary">Also vibrate when a new message arrives</string>
+    <string name="pref_pebble">Pebble</string>
+    <string name="pref_pebble_summary">Notify a connected pebble when a new message arrives</string>
     <string name="pref_sound">Sound</string>
     <string name="pref_sound_summary">Play ringtone with notification</string>
     <string name="pref_conference_notifications">Conference notifications</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -63,6 +63,12 @@
             android:key="vibrate_on_notification"
             android:summary="@string/pref_vibrate_summary"
             android:title="@string/pref_vibrate" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="show_notification"
+            android:key="pebble_notification"
+            android:summary="@string/pref_pebble_summary"
+            android:title="@string/pref_pebble" />
 
         <RingtonePreference
             android:defaultValue="content://settings/system/notification_sound"


### PR DESCRIPTION
IM messages can be quite intense, as there's no rate limiting.
This patch adds a checkbox to enable/disable notifications being sent to a pebble.