### PR TITLE
Use margin instead of padding on about screen

### DIFF
--- a/src/main/res/layout/activity_about.xml
+++ b/src/main/res/layout/activity_about.xml
@@ -2,10 +2,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="eu.siacs.conversations.ui.AboutActivity"
     android:background="@color/primarybackground"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent">
 
@@ -15,6 +11,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:linksClickable="true"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginRight="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginBottom="@dimen/activity_vertical_margin"
         android:textColor="@color/primarytext"
         android:textSize="?attr/TextSizeBody"
         android:typeface="monospace"/>


### PR DESCRIPTION
This is a fix for a minor bug that didn't cause issues on Android 4 (except that the scroll bar was offset over the text a bit, but that was hardly noticable). However, on Android 5 the "pull down" animation is cut off on the edges.

Before:

![before](https://cloud.githubusercontent.com/assets/512573/5715918/24bc44a4-9ab0-11e4-8396-3fefb2d42ab9.png)

After:

![after](https://cloud.githubusercontent.com/assets/512573/5715920/2bcf1064-9ab0-11e4-9a5d-74bdbb77804c.png)

