### PR TITLE
Fix bottom padding on about page

### DIFF
--- a/src/main/res/layout/activity_about.xml
+++ b/src/main/res/layout/activity_about.xml
@@ -14,7 +14,7 @@
         android:layout_marginLeft="@dimen/activity_horizontal_margin"
         android:layout_marginRight="@dimen/activity_horizontal_margin"
         android:layout_marginTop="@dimen/activity_vertical_margin"
-        android:layout_marginBottom="@dimen/activity_vertical_margin"
+        android:paddingBottom="@dimen/activity_vertical_margin"
         android:textColor="@color/primarytext"
         android:textSize="?attr/TextSizeBody"
         android:typeface="monospace"/>


### PR DESCRIPTION
The bottom spacing on the about page should still use padding instead of a margin, otherwise the scrollview cuts the last line of text off (sorry, didn't notice this in my last PR related to this issue).