### PR TITLE
Add option to swap enter/emoticon key

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -15,6 +15,7 @@ import android.os.SystemClock;
 import android.provider.MediaStore;
 import android.support.v4.widget.SlidingPaneLayout;
 import android.support.v4.widget.SlidingPaneLayout.PanelSlideListener;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -32,6 +33,7 @@ import net.java.otr4j.session.SessionStatus;
 import java.util.ArrayList;
 import java.util.List;
 
+import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Blockable;
@@ -133,7 +135,7 @@ public class ConversationActivity extends XmppActivity
 	}
 
 	@Override
-	protected void onCreate(Bundle savedInstanceState) {
+	protected void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		if (savedInstanceState != null) {mOpenConverstaion = savedInstanceState.getString(
 				STATE_OPEN_CONVERSATION, null);
@@ -536,25 +538,25 @@ public class ConversationActivity extends XmppActivity
 		}
 		attachFilePopup.setOnMenuItemClickListener(new OnMenuItemClickListener() {
 
-				@Override
-				public boolean onMenuItemClick(MenuItem item) {
-					switch (item.getItemId()) {
-						case R.id.attach_choose_picture:
-							attachFile(ATTACHMENT_CHOICE_CHOOSE_IMAGE);
-							break;
-						case R.id.attach_take_picture:
-							attachFile(ATTACHMENT_CHOICE_TAKE_PHOTO);
-							break;
-						case R.id.attach_choose_file:
-							attachFile(ATTACHMENT_CHOICE_CHOOSE_FILE);
-							break;
-						case R.id.attach_record_voice:
-							attachFile(ATTACHMENT_CHOICE_RECORD_VOICE);
-							break;
-					}
-					return false;
+			@Override
+			public boolean onMenuItemClick(MenuItem item) {
+				switch (item.getItemId()) {
+					case R.id.attach_choose_picture:
+						attachFile(ATTACHMENT_CHOICE_CHOOSE_IMAGE);
+						break;
+					case R.id.attach_take_picture:
+						attachFile(ATTACHMENT_CHOICE_TAKE_PHOTO);
+						break;
+					case R.id.attach_choose_file:
+						attachFile(ATTACHMENT_CHOICE_CHOOSE_FILE);
+						break;
+					case R.id.attach_record_voice:
+						attachFile(ATTACHMENT_CHOICE_RECORD_VOICE);
+						break;
 				}
-			});
+				return false;
+			}
+		});
 		attachFilePopup.show();
 	}
 
@@ -750,8 +752,9 @@ public class ConversationActivity extends XmppActivity
 	@Override
 	public void onResume() {
 		super.onResume();
-		int theme = findTheme();
-		if (this.mTheme != theme) {
+		final int theme = findTheme();
+		final boolean usingEnterKey = usingEnterKey();
+		if (this.mTheme != theme || usingEnterKey != mUsingEnterKey) {
 			recreate();
 		}
 		this.mActivityPaused = false;

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.os.Bundle;
+import android.text.InputType;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.Gravity;
@@ -300,12 +301,21 @@ public class ConversationFragment extends Fragment {
 		}
 	}
 
+	private void setupIme() {
+		if (((ConversationActivity)getActivity()).usingEnterKey()) {
+			mEditMessage.setInputType(mEditMessage.getInputType() & (~InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE));
+		} else {
+			mEditMessage.setInputType(mEditMessage.getInputType() | InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE);
+		}
+	}
+
 	@Override
 	public View onCreateView(final LayoutInflater inflater,
 			ViewGroup container, Bundle savedInstanceState) {
 		final View view = inflater.inflate(R.layout.fragment_conversation,
 				container, false);
 		mEditMessage = (EditMessage) view.findViewById(R.id.textinput);
+		setupIme();
 		mEditMessage.setOnClickListener(new OnClickListener() {
 
 			@Override
@@ -421,24 +431,24 @@ public class ConversationFragment extends Fragment {
 					|| m.getType() == Message.TYPE_PRIVATE
 					|| m.getDownloadable() != null) {
 				shareWith.setVisible(false);
-			}
+					}
 			if (m.getStatus() != Message.STATUS_SEND_FAILED) {
 				sendAgain.setVisible(false);
 			}
 			if ((m.getType() != Message.TYPE_IMAGE && m.getDownloadable() == null)
 					|| m.getImageParams().url == null) {
 				copyUrl.setVisible(false);
-			}
+					}
 			if (m.getType() != Message.TYPE_TEXT
 					|| m.getDownloadable() != null
 					|| !m.bodyContainsDownloadable()) {
 				downloadImage.setVisible(false);
-			}
+					}
 			if (!((m.getDownloadable() != null && !(m.getDownloadable() instanceof DownloadablePlaceholder))
 						|| (m.isFileOrImage() && (m.getStatus() == Message.STATUS_WAITING
-					|| m.getStatus() == Message.STATUS_OFFERED)))) {
+								|| m.getStatus() == Message.STATUS_OFFERED)))) {
 				cancelTransmission.setVisible(false);
-			}
+								}
 		}
 	}
 

--- a/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
@@ -96,6 +96,7 @@ public abstract class XmppActivity extends Activity {
 
 	private DisplayMetrics metrics;
 	protected int mTheme;
+	protected boolean mUsingEnterKey = false;
 
 	protected interface OnValueEdited {
 		public void onValueEdited(String value);
@@ -303,7 +304,12 @@ public abstract class XmppActivity extends Activity {
 				R.color.secondarybackground);
 		this.mTheme = findTheme();
 		setTheme(this.mTheme);
+		this.mUsingEnterKey = usingEnterKey();
 		mUseSubject = getPreferences().getBoolean("use_subject", true);
+	}
+
+	protected boolean usingEnterKey() {
+		return getPreferences().getBoolean("display_enter_key", false);
 	}
 
 	protected SharedPreferences getPreferences() {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -435,6 +435,8 @@
 	<string name="pref_input_options">Input options</string>
 	<string name="pref_enter_is_send">Enter is send</string>
 	<string name="pref_enter_is_send_summary">Use enter key to send message</string>
+	<string name="pref_display_enter_key">Show enter key</string>
+	<string name="pref_display_enter_key_summary">Change the emoticons key to an enter key</string>
 	<string name="audio">audio file</string>
 	<string name="video">video file</string>
 	<string name="pdf_document">PDF document</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -128,6 +128,11 @@
 			        android:key="enter_is_send"
 			        android:title="@string/pref_enter_is_send"
 			        android:summary="@string/pref_enter_is_send_summary" />
+		        <CheckBoxPreference
+			        android:defaultValue="false"
+			        android:key="display_enter_key"
+			        android:title="@string/pref_display_enter_key"
+			        android:summary="@string/pref_display_enter_key_summary" />
 	        </PreferenceCategory>
             <PreferenceCategory android:title="@string/pref_expert_options_other" >
                 <CheckBoxPreference


### PR DESCRIPTION
Adds a second input option to compliment the new "enter is send" option which allows the emoticons key to be replaced with an enter key (and makes sure the fragment gets reset when it's changed so that it actually shows up without requiring an app restart).

![screenshot](https://cloud.githubusercontent.com/assets/512573/5746999/562cffe4-9c02-11e4-9f1d-2d3ba6dc2f3c.png)
