### PR TITLE
Add mute/unmute to conference details

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -24,9 +24,6 @@ import android.widget.Toast;
 
 import org.openintents.openpgp.util.OpenPgpUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import eu.siacs.conversations.R;
 import eu.siacs.conversations.crypto.PgpEngine;
 import eu.siacs.conversations.entities.Account;
@@ -36,14 +33,14 @@ import eu.siacs.conversations.entities.Conversation;
 import eu.siacs.conversations.entities.MucOptions;
 import eu.siacs.conversations.entities.MucOptions.User;
 import eu.siacs.conversations.services.XmppConnectionService;
-import eu.siacs.conversations.services.XmppConnectionService.OnMucRosterUpdate;
 import eu.siacs.conversations.services.XmppConnectionService.OnConversationUpdate;
+import eu.siacs.conversations.services.XmppConnectionService.OnMucRosterUpdate;
 import eu.siacs.conversations.xmpp.jid.Jid;
 
 public class ConferenceDetailsActivity extends XmppActivity implements OnConversationUpdate, OnMucRosterUpdate, XmppConnectionService.OnAffiliationChanged, XmppConnectionService.OnRoleChanged, XmppConnectionService.OnConferenceOptionsPushed {
 	public static final String ACTION_VIEW_MUC = "view_muc";
 	private Conversation mConversation;
-	private OnClickListener inviteListener = new OnClickListener() {
+	private final OnClickListener inviteListener = new OnClickListener() {
 
 		@Override
 		public void onClick(View v) {
@@ -52,8 +49,6 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 	};
 	private TextView mYourNick;
 	private ImageView mYourPhoto;
-	private ImageButton mEditNickButton;
-	private TextView mRoleAffiliaton;
 	private TextView mFullJid;
 	private TextView mAccountJid;
 	private LinearLayout membersView;
@@ -66,7 +61,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 
 	private boolean mAdvancedMode = false;
 
-	private UiCallback<Conversation> renameCallback = new UiCallback<Conversation>() {
+	private final UiCallback<Conversation> renameCallback = new UiCallback<Conversation>() {
 		@Override
 		public void success(Conversation object) {
 			runOnUiThread(new Runnable() {
@@ -94,14 +89,14 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 
 		}
 	};
-	private OnClickListener mChangeConferenceSettings = new OnClickListener() {
+	private final OnClickListener mChangeConferenceSettings = new OnClickListener() {
 		@Override
 		public void onClick(View v) {
 			final MucOptions mucOptions = mConversation.getMucOptions();
-			AlertDialog.Builder builder = new AlertDialog.Builder(ConferenceDetailsActivity.this);
+			final AlertDialog.Builder builder = new AlertDialog.Builder(ConferenceDetailsActivity.this);
 			builder.setTitle(R.string.conference_options);
-			String[] options = {getString(R.string.members_only),
-					getString(R.string.non_anonymous)};
+			final String[] options = {getString(R.string.members_only),
+				getString(R.string.non_anonymous)};
 			final boolean[] values = new boolean[options.length];
 			values[0] = mucOptions.membersOnly();
 			values[1] = mucOptions.nonanonymous();
@@ -146,6 +141,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 
 			@Override
 			public void run() {
+				invalidateOptionsMenu();
 				updateView();
 			}
 		});
@@ -163,12 +159,12 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 	}
 
 	@Override
-	protected void onCreate(Bundle savedInstanceState) {
+	protected void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_muc_details);
 		mYourNick = (TextView) findViewById(R.id.muc_your_nick);
 		mYourPhoto = (ImageView) findViewById(R.id.your_photo);
-		mEditNickButton = (ImageButton) findViewById(R.id.edit_nick_button);
+		final ImageButton mEditNickButton = (ImageButton) findViewById(R.id.edit_nick_button);
 		mFullJid = (TextView) findViewById(R.id.muc_jabberid);
 		membersView = (LinearLayout) findViewById(R.id.muc_members);
 		mAccountJid = (TextView) findViewById(R.id.details_account);
@@ -193,7 +189,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 
 							@Override
 							public void onValueEdited(String value) {
-								xmppConnectionService.renameInMuc(mConversation,value,renameCallback);
+								xmppConnectionService.renameInMuc(mConversation, value, renameCallback);
 							}
 						});
 			}
@@ -223,8 +219,20 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 				invalidateOptionsMenu();
 				updateView();
 				break;
+			case R.id.action_mute:
+				MuteConversationDialog.show(this, xmppConnectionService, mConversation);
+				break;
+			case R.id.action_unmute:
+				unmuteConversation(mConversation);
+				break;
 		}
 		return super.onOptionsItemSelected(menuItem);
+	}
+
+	private void unmuteConversation(final Conversation conversation) {
+		conversation.setMutedTill(0);
+		this.xmppConnectionService.databaseBackend.updateConversation(conversation);
+		invalidateOptionsMenu();
 	}
 
 	@Override
@@ -256,6 +264,11 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
 		getMenuInflater().inflate(R.menu.muc_details, menu);
+		if (mConversation.isMuted()) {
+			menu.findItem(R.id.action_mute).setVisible(false);
+		} else {
+			menu.findItem(R.id.action_unmute).setVisible(false);
+		}
 		return true;
 	}
 
@@ -301,7 +314,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 					} else {
 						removeAdminPrivileges.setVisible(true);
 					}
-				}
+						}
 			}
 
 		}
@@ -408,7 +421,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 		setTitle(mConversation.getName());
 		mFullJid.setText(mConversation.getJid().toBareJid().toString());
 		mYourNick.setText(mucOptions.getActualNick());
-		mRoleAffiliaton = (TextView) findViewById(R.id.muc_role);
+		final TextView mRoleAffiliaton = (TextView) findViewById(R.id.muc_role);
 		if (mucOptions.online()) {
 			mMoreDetails.setVisibility(View.VISIBLE);
 			final String status = getStatus(self);

--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -11,7 +11,6 @@ import android.content.Intent;
 import android.content.IntentSender.SendIntentException;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.SystemClock;
 import android.provider.MediaStore;
 import android.support.v4.widget.SlidingPaneLayout;
 import android.support.v4.widget.SlidingPaneLayout.PanelSlideListener;
@@ -449,7 +448,7 @@ public class ConversationActivity extends XmppActivity
 					clearHistoryDialog(getSelectedConversation());
 					break;
 				case R.id.action_mute:
-					muteConversationDialog(getSelectedConversation());
+					MuteConversationDialog.show(this, xmppConnectionService, getSelectedConversation());
 					break;
 				case R.id.action_unmute:
 					unmuteConversation(getSelectedConversation());
@@ -652,34 +651,6 @@ public class ConversationActivity extends XmppActivity
 			}
 			popup.show();
 		}
-	}
-
-	protected void muteConversationDialog(final Conversation conversation) {
-		AlertDialog.Builder builder = new AlertDialog.Builder(this);
-		builder.setTitle(R.string.disable_notifications);
-		final int[] durations = getResources().getIntArray(
-				R.array.mute_options_durations);
-		builder.setItems(R.array.mute_options_descriptions,
-				new OnClickListener() {
-
-					@Override
-					public void onClick(final DialogInterface dialog, final int which) {
-						final long till;
-						if (durations[which] == -1) {
-							till = Long.MAX_VALUE;
-						} else {
-							till = SystemClock.elapsedRealtime()
-								+ (durations[which] * 1000);
-						}
-						conversation.setMutedTill(till);
-						ConversationActivity.this.xmppConnectionService.databaseBackend
-							.updateConversation(conversation);
-						updateConversationList();
-						ConversationActivity.this.mConversationFragment.updateMessages();
-						invalidateOptionsMenu();
-					}
-				});
-		builder.create().show();
 	}
 
 	public void unmuteConversation(final Conversation conversation) {
@@ -1016,6 +987,7 @@ public class ConversationActivity extends XmppActivity
 			@Override
 			public void run() {
 				updateConversationList();
+				invalidateOptionsMenu();
 				if (conversationList.size() == 0) {
 					startActivity(new Intent(getApplicationContext(),
 								StartConversationActivity.class));

--- a/src/main/java/eu/siacs/conversations/ui/MuteConversationDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/MuteConversationDialog.java
@@ -1,0 +1,40 @@
+package eu.siacs.conversations.ui;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.SystemClock;
+
+import eu.siacs.conversations.R;
+import eu.siacs.conversations.entities.Conversation;
+import eu.siacs.conversations.services.XmppConnectionService;
+
+public final class MuteConversationDialog {
+	public static void show(final Context context,
+			final XmppConnectionService xmppConnectionService,
+			final Conversation conversation) {
+		final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+		builder.setTitle(R.string.disable_notifications);
+		final int[] durations = context.getResources().getIntArray(
+				R.array.mute_options_durations);
+		builder.setItems(R.array.mute_options_descriptions,
+				new DialogInterface.OnClickListener() {
+
+					@Override
+					public void onClick(final DialogInterface dialog, final int which) {
+						final long till;
+						if (durations[which] == -1) {
+							till = Long.MAX_VALUE;
+						} else {
+							till = SystemClock.elapsedRealtime()
+								+ (durations[which] * 1000);
+						}
+						conversation.setMutedTill(till);
+						xmppConnectionService.databaseBackend
+							.updateConversation(conversation);
+						xmppConnectionService.updateConversationUi();
+					}
+				});
+		builder.create().show();
+	}
+}

--- a/src/main/res/menu/conversations.xml
+++ b/src/main/res/menu/conversations.xml
@@ -44,6 +44,7 @@
         android:orderInCategory="60"
         android:showAsAction="never"
         android:title="@string/action_end_conversation"/>
+
     <item
         android:id="@+id/action_mute"
         android:orderInCategory="70"
@@ -61,6 +62,7 @@
         android:orderInCategory="90"
         android:showAsAction="never"
         android:title="@string/action_accounts"/>
+
     <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"

--- a/src/main/res/menu/muc_details.xml
+++ b/src/main/res/menu/muc_details.xml
@@ -29,6 +29,17 @@
 		android:orderInCategory="85"
 		android:showAsAction="never" />
     <item
+        android:id="@+id/action_mute"
+        android:orderInCategory="70"
+        android:showAsAction="never"
+        android:title="@string/disable_notifications"/>
+
+    <item
+        android:id="@+id/action_unmute"
+        android:orderInCategory="71"
+        android:showAsAction="never"
+        android:title="@string/enable_notifications"/>
+    <item
         android:id="@+id/action_accounts"
         android:orderInCategory="90"
         android:showAsAction="never"


### PR DESCRIPTION
This PR adds mute/unmute to the conference details view (while it could go in the contact one too, mute/unmute is more an action on a conversation than the actual contact, and the contact details view definitely describes a contact while the conference details view describes a conversation).