### PR TITLE
Add some Android 21 notification features

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -203,6 +203,10 @@ public class NotificationService {
 					mBuilder.setSound(Uri.parse(ringtone));
 				}
 			}
+			if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				mBuilder.setCategory(Notification.CATEGORY_MESSAGE);
+				mBuilder.setColor(mXmppConnectionService.getResources().getColor(R.color.primary));
+			}
 			mBuilder.setSmallIcon(R.drawable.ic_notification);
 			mBuilder.setDeleteIntent(createDeleteIntent());
 			mBuilder.setLights(0xffffffff, 2000, 4000);


### PR DESCRIPTION
Adds two of the new notification features from API 21: Colored icon background and category (used for prioritizing messages, eg. users can specify that they don't want to be interrupted by anything but SMS/IM messages).

![6cd1d95e-6e1b-4e03-8477-288cd0a3d7e8](https://cloud.githubusercontent.com/assets/512573/5791420/2817f0b6-9ea3-11e4-8b08-d4d972c846c2.png)