### PR TITLE
Remove legacy SSL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ proguard/
 .idea
 
 import-summary.txt
+.navigation/

--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -507,22 +507,18 @@ public class XmppConnection implements Runnable {
 			}
 
 			final String[] supportProtocols;
-			if (enableLegacySSL()) {
-				supportProtocols = sslSocket.getSupportedProtocols();
-			} else {
-				final Collection<String> supportedProtocols = new LinkedList<>(
-						Arrays.asList(sslSocket.getSupportedProtocols()));
-				supportedProtocols.remove("SSLv3");
-				supportProtocols = new String[supportedProtocols.size()];
-				supportedProtocols.toArray(supportProtocols);
+			final Collection<String> supportedProtocols = new LinkedList<>(
+					Arrays.asList(sslSocket.getSupportedProtocols()));
+			supportedProtocols.remove("SSLv3");
+			supportProtocols = supportedProtocols.toArray(new String[supportedProtocols.size()]);
 
-				final String[] cipherSuites = CryptoHelper.getSupportedCipherSuites(
-						sslSocket.getSupportedCipherSuites());
-				if (cipherSuites.length > 0) {
-					sslSocket.setEnabledCipherSuites(cipherSuites);
-				}
-			}
 			sslSocket.setEnabledProtocols(supportProtocols);
+
+			final String[] cipherSuites = CryptoHelper.getSupportedCipherSuites(
+					sslSocket.getSupportedCipherSuites());
+			if (cipherSuites.length > 0) {
+				sslSocket.setEnabledCipherSuites(cipherSuites);
+			}
 
 			if (!verifier.verify(account.getServer().getDomainpart(),sslSocket.getSession())) {
 				Log.d(Config.LOGTAG,account.getJid().toBareJid()+": TLS certificate verification failed");

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -267,7 +267,6 @@
   <string name="pref_force_encryption_summary">Vždy zasílat šifrované zprávy (mimo konference)</string>
   <string name="pref_dont_save_encrypted">Neukládat šifrované zprávy</string>
   <string name="pref_dont_save_encrypted_summary">Varování: Toto může vést ke ztrátě zpráv</string>
-  <string name="pref_enable_legacy_ssl">Povolit zastaralé SSL</string>
   <string name="pref_expert_options">Expertní nastavení</string>
   <string name="pref_expert_options_summary">S tímto zacházejte velmi opatrně</string>
   <string name="title_activity_about">O aplikaci Conversations</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -267,7 +267,6 @@
   <string name="pref_force_encryption_summary">Nachrichten immer verschlüsseln (außer für Konferenzen)</string>
   <string name="pref_dont_save_encrypted">Verschlüsselte Nachrichten nicht speichern</string>
   <string name="pref_dont_save_encrypted_summary">Achtung: kann zu Nachrichtenverlust führen</string>
-  <string name="pref_enable_legacy_ssl">Alte SSL-Version aktivieren</string>
   <string name="pref_expert_options">Einstellungen für Experten</string>
   <string name="pref_expert_options_summary">Hier bitte vorsichtig sein</string>
   <string name="title_activity_about">Über Conversations</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -267,7 +267,6 @@
   <string name="pref_force_encryption_summary">Siempre enviar mensajes cifrados (excepto para conversaciones en grupo)</string>
   <string name="pref_dont_save_encrypted">No guardar mensajes cifrados</string>
   <string name="pref_dont_save_encrypted_summary">Aviso: Esto podría llevar a pérdida de mensajes</string>
-  <string name="pref_enable_legacy_ssl">Habilitar SSL heredado</string>
   <string name="pref_expert_options">Ajustes avanzados</string>
   <string name="pref_expert_options_summary">Por favor, cuidado con estas opciones</string>
   <string name="title_activity_about">Acerca de Conversations</string>

--- a/src/main/res/values-eu/strings.xml
+++ b/src/main/res/values-eu/strings.xml
@@ -267,7 +267,6 @@
   <string name="pref_force_encryption_summary">Mezuak beti enkriptatuta bidali (konferentzietan izan ezik)</string>
   <string name="pref_dont_save_encrypted">Ez gorde enkriptatutako mezuak</string>
   <string name="pref_dont_save_encrypted_summary">Adi: Honek mezuen galera ekar lezake</string>
-  <string name="pref_enable_legacy_ssl">Oinordetutako SSL gaitu</string>
   <string name="pref_expert_options">Adituentzako aukerak</string>
   <string name="pref_expert_options_summary">Mesedez kontuz ibili hauekin</string>
   <string name="title_activity_about">Conversationsi buruz</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -267,7 +267,6 @@
   <string name="pref_force_encryption_summary">Toujours envoyer des messages chiffrés (sauf pour les conférences)</string>
   <string name="pref_dont_save_encrypted">Ne pas sauvegarder les messages chiffrés</string>
   <string name="pref_dont_save_encrypted_summary">Attention: Celà peut mener à une perte de messages</string>
-  <string name="pref_enable_legacy_ssl">Activer SSL hérité</string>
   <string name="pref_expert_options">Options avancées</string>
   <string name="pref_expert_options_summary">A utiliser avec précautions</string>
   <string name="title_activity_about">Sur Conversations</string>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -267,7 +267,6 @@
   <string name="pref_force_encryption_summary">Manda sempre messaggi cifrati (ad eccezione delle conferenze)</string>
   <string name="pref_dont_save_encrypted">Non salvare i messaggi cifrati</string>
   <string name="pref_dont_save_encrypted_summary">Attenzione: Questo potrebbe comportare la perdita di messaggi</string>
-  <string name="pref_enable_legacy_ssl">Abilita il vecchio SSL</string>
   <string name="pref_expert_options">Opzioni da Esperto</string>
   <string name="pref_expert_options_summary">Fai attenzione con queste impostazioni</string>
   <string name="title_activity_about">Info su Conversations</string>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -267,7 +267,6 @@
   <string name="pref_force_encryption_summary">Stuur berichten altijd versleuteld (behalve in groepsgesprekken)</string>
   <string name="pref_dont_save_encrypted">Sla versleutelde berichten niet op</string>
   <string name="pref_dont_save_encrypted_summary"><b>Waarschuwing:</b> Dit kan leiden tot verlies van berichten</string>
-  <string name="pref_enable_legacy_ssl">Sta legacy SSL toe</string>
   <string name="pref_expert_options">Expert-instellingen</string>
   <string name="pref_expert_options_summary">Wees voorzichtig met deze instellingen</string>
   <string name="title_activity_about">Over Conversations</string>

--- a/src/main/res/values-sv/strings.xml
+++ b/src/main/res/values-sv/strings.xml
@@ -267,7 +267,6 @@
   <string name="pref_force_encryption_summary">Sänd alltid krypterade meddelanden (utom för konferenser)</string>
   <string name="pref_dont_save_encrypted">Spara in krypterade meddelanden</string>
   <string name="pref_dont_save_encrypted_summary">Varning: Detta kan leda till att meddelanden förloras</string>
-  <string name="pref_enable_legacy_ssl">Aktivera förlegad SSL</string>
   <string name="pref_expert_options">Expertinställningar</string>
   <string name="pref_expert_options_summary">Var försiktig med dem</string>
   <string name="title_activity_about">Om Conversations</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -269,8 +269,6 @@
     <string name="pref_force_encryption_summary">Always send messages encrypted (except for conferences)</string>
     <string name="pref_dont_save_encrypted">Don’t save encrypted messages</string>
     <string name="pref_dont_save_encrypted_summary">Warning: This could lead to message loss</string>
-    <string name="pref_enable_legacy_ssl">Enable legacy SSL</string>
-    <string name="pref_enable_legacy_ssl_summary">Enables legacy SSLv3 support and insecure SSL ciphers.</string>
     <string name="pref_expert_options">Expert options</string>
     <string name="pref_expert_options_summary">Please be careful with these</string>
     <string name="title_activity_about">About Conversations</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -116,11 +116,6 @@
                     android:key="dont_save_encrypted"
                     android:summary="@string/pref_dont_save_encrypted_summary"
                     android:title="@string/pref_dont_save_encrypted" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="enable_legacy_ssl"
-                    android:summary="@string/pref_enable_legacy_ssl_summary"
-                    android:title="@string/pref_enable_legacy_ssl" />
             </PreferenceCategory>
 	        <PreferenceCategory android:title="@string/pref_input_options">
 		        <CheckBoxPreference


### PR DESCRIPTION
Removes legacy SSL support (and gitignores the navigation builder tool's temp files, which was apparently still in my .gitignore file when I committed).