### PR TITLE
otr4j: update to 0.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	compile project(':libs:MemorizingTrustManager')
 	compile 'com.android.support:support-v13:21.0.3'
 	compile 'org.bouncycastle:bcprov-jdk15on:1.50'
-	compile 'net.java:otr4j:0.21'
+	compile 'net.java:otr4j:0.22'
 	compile 'org.gnu.inet:libidn:1.15'
 	compile 'com.google.zxing:core:3.1.0'
 	compile 'com.google.zxing:android-integration:3.1.0'

--- a/src/main/java/eu/siacs/conversations/crypto/OtrEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/OtrEngine.java
@@ -33,6 +33,7 @@ import net.java.otr4j.crypto.OtrCryptoEngineImpl;
 import net.java.otr4j.crypto.OtrCryptoException;
 import net.java.otr4j.session.InstanceTag;
 import net.java.otr4j.session.SessionID;
+import net.java.otr4j.session.FragmenterInstructions;
 
 public class OtrEngine extends OtrCryptoEngineImpl implements OtrEngineHost {
 
@@ -267,6 +268,11 @@ public class OtrEngine extends OtrCryptoEngineImpl implements OtrEngineHost {
 			}
 		} catch (final InvalidJidException ignored) {
 		}
+	}
+
+	@Override
+	public FragmenterInstructions getFragmenterInstructions(SessionID sessionID) {
+		return null;
 	}
 
 }

--- a/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
+++ b/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
@@ -68,7 +68,7 @@ public class MessageGenerator extends AbstractGenerator {
 		packet.addChild("private", "urn:xmpp:carbons:2");
 		packet.addChild("no-copy", "urn:xmpp:hints");
 		try {
-			packet.setBody(otrSession.transformSending(message.getBody()));
+			packet.setBody(otrSession.transformSending(message.getBody())[0]);
 			return packet;
 		} catch (OtrException e) {
 			return null;

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -1688,7 +1688,7 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 			try {
 				packet.setBody(otrSession
 						.transformSending(CryptoHelper.FILETRANSFER
-								+ CryptoHelper.bytesToHex(symmetricKey)));
+								+ CryptoHelper.bytesToHex(symmetricKey))[0]);
 				sendMessagePacket(account, packet);
 				conversation.setSymmetricKey(symmetricKey);
 				return true;


### PR DESCRIPTION
Hi,

you should update otr4j to version 0.22
see otr4j/otr4j#6 and jitsi/otr4j#20

otr4j supports in this version fragmentation so the api has changed slightly.
transformSending() returns now an array of strings.
