### PR TITLE
MessageParser: fix the regex for otr query messages.

### DIFF
--- a/src/main/java/eu/siacs/conversations/parser/MessageParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/MessageParser.java
@@ -75,7 +75,7 @@ public class MessageParser extends AbstractParser implements
 		}
 		updateLastseen(packet, account, true);
 		String body = packet.getBody();
-		if (body.matches("^\\?OTRv\\d*\\?")) {
+		if (body.matches("^\\?OTRv\\d{1,2}\\?.*")) {
 			conversation.endOtrIfNeeded();
 		}
 		if (!conversation.hasValidOtrSession()) {


### PR DESCRIPTION
Hi,

when the otr query messages have an additional message like conversations used
 *"I would like to start a private (OTR encrypted) conversation but your client doesn’t seem to support that"* 
the the regex does not mach.