### PR TITLE
Show errors before mute snackbar

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -612,15 +612,6 @@ public class ConversationFragment extends Fragment {
 									}
 								}
 							});
-				} else if (this.conversation.isMuted()) {
-					showSnackbar(R.string.notifications_disabled, R.string.enable,
-							new OnClickListener() {
-
-								@Override
-								public void onClick(final View v) {
-									activity.unmuteConversation(conversation);
-								}
-							});
 				} else if (!contact.showInRoster()
 						&& contact
 						.getOption(Contact.Options.PENDING_SUBSCRIPTION_REQUEST)) {
@@ -667,7 +658,16 @@ public class ConversationFragment extends Fragment {
 						default:
 							break;
 					}
-						}
+				} else if (this.conversation.isMuted()) {
+					showSnackbar(R.string.notifications_disabled, R.string.enable,
+							new OnClickListener() {
+
+								@Override
+								public void onClick(final View v) {
+									activity.unmuteConversation(conversation);
+								}
+							});
+				}
 				conversation.populateWithMessages(ConversationFragment.this.messageList);
 				for (final Message message : this.messageList) {
 					if (message.getEncryption() == Message.ENCRYPTION_PGP


### PR DESCRIPTION
Lower the priority of the "muted" snackbar below actual errors (eg. "nick is already taken") as we should probably not be required to unmute a conference to actually join it when things like this happen.

Fixes #939