### PR TITLE
Message pull-to-refresh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	compile project(':libs:openpgp-api-lib')
 	compile project(':libs:MemorizingTrustManager')
 	compile 'com.android.support:support-v13:21.0.3'
+	compile 'com.android.support:support-v4:21.0.3'
 	compile 'org.bouncycastle:bcprov-jdk15on:1.50'
 	compile 'net.java:otr4j:0.22'
 	compile 'org.gnu.inet:libidn:1.15'

--- a/src/main/java/eu/siacs/conversations/services/MessageArchiveService.java
+++ b/src/main/java/eu/siacs/conversations/services/MessageArchiveService.java
@@ -303,7 +303,7 @@ public class MessageArchiveService implements OnAdvancedStreamFeaturesLoaded {
 			if (this.callback != null) {
 				this.callback.onMoreMessagesLoaded(messageCount,conversation);
 				if (messageCount == 0) {
-					this.callback.informUser(R.string.no_more_history_on_server);
+					this.callback.informUser();
 				}
 			}
 		}

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -976,7 +976,7 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 					if (query != null) {
 						query.setCallback(callback);
 					}
-					callback.informUser(R.string.fetching_history_from_server);
+					callback.informUser();
 				}
 			}
 		}).start();
@@ -2285,7 +2285,7 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 	public interface OnMoreMessagesLoaded {
 		public void onMoreMessagesLoaded(int count, Conversation conversation);
 
-		public void informUser(int r);
+		public void informUser();
 	}
 
 	public interface OnAccountPasswordChanged {

--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -14,6 +14,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.support.v4.widget.SlidingPaneLayout;
 import android.support.v4.widget.SlidingPaneLayout.PanelSlideListener;
 import android.view.Menu;
@@ -34,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import eu.siacs.conversations.R;
-import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Blockable;
 import eu.siacs.conversations.entities.Contact;
 import eu.siacs.conversations.entities.Conversation;
@@ -77,7 +77,6 @@ public class ConversationActivity extends XmppActivity
 
 	private List<Conversation> conversationList = new ArrayList<>();
 	private Conversation mSelectedConversation = null;
-	private ListView listView;
 	private ConversationFragment mConversationFragment;
 
 	private ArrayAdapter<Conversation> listAdapter;
@@ -155,7 +154,7 @@ public class ConversationActivity extends XmppActivity
 		transaction.replace(R.id.selected_conversation, this.mConversationFragment, "conversation");
 		transaction.commit();
 
-		listView = (ListView) findViewById(R.id.list);
+		final ListView listView = (ListView) findViewById(R.id.list);
 		this.listAdapter = new ConversationAdapter(this, conversationList);
 		listView.setAdapter(this.listAdapter);
 
@@ -168,7 +167,7 @@ public class ConversationActivity extends XmppActivity
 
 			@Override
 			public void onItemClick(AdapterView<?> arg0, View clickedView,
-					int position, long arg3) {
+			                        int position, long arg3) {
 				if (getSelectedConversation() != conversationList.get(position)) {
 					setSelectedConversation(conversationList.get(position));
 					ConversationActivity.this.mConversationFragment.reInit(getSelectedConversation());
@@ -185,7 +184,7 @@ public class ConversationActivity extends XmppActivity
 			SlidingPaneLayout mSlidingPaneLayout = (SlidingPaneLayout) mContentView;
 			mSlidingPaneLayout.setParallaxDistance(150);
 			mSlidingPaneLayout
-				.setShadowResource(R.drawable.es_slidingpane_shadow);
+				.setShadowResourceLeft(R.drawable.es_slidingpane_shadow);
 			mSlidingPaneLayout.setSliderFadeColor(0);
 			mSlidingPaneLayout.setPanelSlideListener(new PanelSlideListener() {
 
@@ -208,8 +207,6 @@ public class ConversationActivity extends XmppActivity
 
 				@Override
 				public void onPanelSlide(View arg0, float arg1) {
-					// TODO Auto-generated method stub
-
 				}
 			});
 		}
@@ -313,7 +310,6 @@ public class ConversationActivity extends XmppActivity
 					menuInviteContact.setVisible(getSelectedConversation().getMucOptions().canInvite());
 				} else {
 					menuMucDetails.setVisible(false);
-					final Account account = this.getSelectedConversation().getAccount();
 				}
 				if (this.getSelectedConversation().isMuted()) {
 					menuMute.setVisible(false);
@@ -759,7 +755,7 @@ public class ConversationActivity extends XmppActivity
 	}
 
 	@Override
-	public void onSaveInstanceState(final Bundle savedInstanceState) {
+	public void onSaveInstanceState(@NonNull final Bundle savedInstanceState) {
 		Conversation conversation = getSelectedConversation();
 		if (conversation != null) {
 			savedInstanceState.putString(STATE_OPEN_CONVERSATION,

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -105,7 +105,6 @@ public class ConversationFragment extends Fragment implements SwipeRefreshLayout
 	private TextView snackbarMessage;
 	private TextView snackbarAction;
 	private boolean messagesLoaded = true;
-	private Toast messageLoaderToast;
 
 	@Override
 	public void onRefresh() {
@@ -116,8 +115,8 @@ public class ConversationFragment extends Fragment implements SwipeRefreshLayout
 				activity.xmppConnectionService.loadMoreMessages(conversation, timestamp, new XmppConnectionService.OnMoreMessagesLoaded() {
 					@Override
 					public void onMoreMessagesLoaded(final int count, final Conversation conversation) {
+						swipeRefreshLayout.setRefreshing(false);
 						if (ConversationFragment.this.conversation != conversation) {
-							swipeRefreshLayout.setRefreshing(false);
 							return;
 						}
 						activity.runOnUiThread(new Runnable() {
@@ -144,32 +143,14 @@ public class ConversationFragment extends Fragment implements SwipeRefreshLayout
 									}
 									messagesView.setSelectionFromTop(newPosition - offset, pxOffset);
 									messagesLoaded = true;
-									if (messageLoaderToast != null) {
-										messageLoaderToast.cancel();
-									}
 								}
 							}
 						});
 					}
 
 					@Override
-					public void informUser(final int resId) {
+					public void informUser() {
 						swipeRefreshLayout.setRefreshing(false);
-
-						activity.runOnUiThread(new Runnable() {
-							@Override
-							public void run() {
-								if (messageLoaderToast != null) {
-									messageLoaderToast.cancel();
-								}
-								if (ConversationFragment.this.conversation != conversation) {
-									return;
-								}
-								messageLoaderToast = Toast.makeText(activity,resId,Toast.LENGTH_LONG);
-								messageLoaderToast.show();
-							}
-						});
-
 					}
 				});
 			} else {

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.os.Bundle;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.InputType;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
@@ -21,8 +22,6 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.AbsListView;
-import android.widget.AbsListView.OnScrollListener;
 import android.widget.AdapterView;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.ImageButton;
@@ -60,7 +59,7 @@ import eu.siacs.conversations.ui.adapter.MessageAdapter.OnContactPictureClicked;
 import eu.siacs.conversations.ui.adapter.MessageAdapter.OnContactPictureLongClicked;
 import eu.siacs.conversations.xmpp.jid.Jid;
 
-public class ConversationFragment extends Fragment {
+public class ConversationFragment extends Fragment implements SwipeRefreshLayout.OnRefreshListener {
 
 	protected Conversation conversation;
 	private OnClickListener leaveMuc = new OnClickListener() {
@@ -97,6 +96,7 @@ public class ConversationFragment extends Fragment {
 		}
 	};
 	protected ListView messagesView;
+	protected SwipeRefreshLayout swipeRefreshLayout;
 	final protected List<Message> messageList = new ArrayList<>();
 	protected MessageAdapter messageListAdapter;
 	private EditMessage mEditMessage;
@@ -107,83 +107,77 @@ public class ConversationFragment extends Fragment {
 	private boolean messagesLoaded = true;
 	private Toast messageLoaderToast;
 
-	private OnScrollListener mOnScrollListener = new OnScrollListener() {
-
-		@Override
-		public void onScrollStateChanged(AbsListView view, int scrollState) {
-			// TODO Auto-generated method stub
-
-		}
-
-		@Override
-		public void onScroll(AbsListView view, int firstVisibleItem,
-				int visibleItemCount, int totalItemCount) {
-			synchronized (ConversationFragment.this.messageList) {
-				if (firstVisibleItem < 5 && messagesLoaded && messageList.size() > 0) {
-					long timestamp = ConversationFragment.this.messageList.get(0).getTimeSent();
-					messagesLoaded = false;
-					activity.xmppConnectionService.loadMoreMessages(conversation, timestamp, new XmppConnectionService.OnMoreMessagesLoaded() {
-						@Override
-						public void onMoreMessagesLoaded(final int count, Conversation conversation) {
-							if (ConversationFragment.this.conversation != conversation) {
-								return;
-							}
-							activity.runOnUiThread(new Runnable() {
-								@Override
-								public void run() {
-									final int oldPosition = messagesView.getFirstVisiblePosition();
-									View v = messagesView.getChildAt(0);
-									final int pxOffset = (v == null) ? 0 : v.getTop();
-									ConversationFragment.this.conversation.populateWithMessages(ConversationFragment.this.messageList);
-									updateStatusMessages();
-									messageListAdapter.notifyDataSetChanged();
-									if (count != 0) {
-										final int newPosition = oldPosition + count;
-										int offset = 0;
-										try {
-											Message tmpMessage = messageList.get(newPosition);
-
-											while(tmpMessage.wasMergedIntoPrevious()) {
-												offset++;
-												tmpMessage = tmpMessage.prev();
-											}
-										} catch (final IndexOutOfBoundsException ignored) {
-
-										}
-										messagesView.setSelectionFromTop(newPosition - offset, pxOffset);
-										messagesLoaded = true;
-										if (messageLoaderToast != null) {
-											messageLoaderToast.cancel();
-										}
-									}
-								}
-							});
+	@Override
+	public void onRefresh() {
+		synchronized (ConversationFragment.this.messageList) {
+			if (messagesLoaded && messageList.size() > 0) {
+				long timestamp = ConversationFragment.this.messageList.get(0).getTimeSent();
+				messagesLoaded = false;
+				activity.xmppConnectionService.loadMoreMessages(conversation, timestamp, new XmppConnectionService.OnMoreMessagesLoaded() {
+					@Override
+					public void onMoreMessagesLoaded(final int count, final Conversation conversation) {
+						if (ConversationFragment.this.conversation != conversation) {
+							swipeRefreshLayout.setRefreshing(false);
+							return;
 						}
+						activity.runOnUiThread(new Runnable() {
+							@Override
+							public void run() {
+								final int oldPosition = messagesView.getFirstVisiblePosition();
+								View v = messagesView.getChildAt(0);
+								final int pxOffset = (v == null) ? 0 : v.getTop();
+								ConversationFragment.this.conversation.populateWithMessages(
+										ConversationFragment.this.messageList);
+								updateStatusMessages();
+								messageListAdapter.notifyDataSetChanged();
+								if (count != 0) {
+									final int newPosition = oldPosition + count;
+									int offset = 0;
+									try {
+										Message tmpMessage = messageList.get(newPosition);
 
-						@Override
-						public void informUser(final int resId) {
-
-							activity.runOnUiThread(new Runnable() {
-								@Override
-								public void run() {
+										while(tmpMessage.wasMergedIntoPrevious()) {
+											offset++;
+											tmpMessage = tmpMessage.prev();
+										}
+									} catch (final IndexOutOfBoundsException ignored) {
+									}
+									messagesView.setSelectionFromTop(newPosition - offset, pxOffset);
+									messagesLoaded = true;
 									if (messageLoaderToast != null) {
 										messageLoaderToast.cancel();
 									}
-									if (ConversationFragment.this.conversation != conversation) {
-										return;
-									}
-									messageLoaderToast = Toast.makeText(activity,resId,Toast.LENGTH_LONG);
-									messageLoaderToast.show();
 								}
-							});
+							}
+						});
+					}
 
-						}
-					});
+					@Override
+					public void informUser(final int resId) {
+						swipeRefreshLayout.setRefreshing(false);
 
-				}
+						activity.runOnUiThread(new Runnable() {
+							@Override
+							public void run() {
+								if (messageLoaderToast != null) {
+									messageLoaderToast.cancel();
+								}
+								if (ConversationFragment.this.conversation != conversation) {
+									return;
+								}
+								messageLoaderToast = Toast.makeText(activity,resId,Toast.LENGTH_LONG);
+								messageLoaderToast.show();
+							}
+						});
+
+					}
+				});
+			} else {
+				swipeRefreshLayout.setRefreshing(false);
 			}
 		}
-	};
+	}
+
 	private IntentSender askForPassphraseIntent = null;
 	protected OnClickListener clickToDecryptListener = new OnClickListener() {
 
@@ -345,8 +339,16 @@ public class ConversationFragment extends Fragment {
 		snackbarMessage = (TextView) view.findViewById(R.id.snackbar_message);
 		snackbarAction = (TextView) view.findViewById(R.id.snackbar_action);
 
+		swipeRefreshLayout = (SwipeRefreshLayout) view.findViewById(R.id.messages_refresh_view);
+		swipeRefreshLayout.setOnRefreshListener(this);
+		swipeRefreshLayout.setColorSchemeResources(
+				android.R.color.holo_blue_bright,
+				android.R.color.holo_green_light,
+				android.R.color.holo_orange_light,
+				android.R.color.holo_red_light
+		);
+
 		messagesView = (ListView) view.findViewById(R.id.messages_view);
-		messagesView.setOnScrollListener(mOnScrollListener);
 		messagesView.setTranscriptMode(ListView.TRANSCRIPT_MODE_NORMAL);
 		messageListAdapter = new MessageAdapter((ConversationActivity) getActivity(), this.messageList);
 		messageListAdapter.setOnContactPictureClicked(new OnContactPictureClicked() {
@@ -699,7 +701,6 @@ public class ConversationFragment extends Fragment {
 				} else if (!contact.showInRoster()
 						&& contact
 						.getOption(Contact.Options.PENDING_SUBSCRIPTION_REQUEST)) {
-
 				} else if (conversation.getMode() == Conversation.MODE_SINGLE) {
 					makeFingerprintWarning();
 				} else if (!conversation.getMucOptions().online()

--- a/src/main/res/layout/fragment_conversation.xml
+++ b/src/main/res/layout/fragment_conversation.xml
@@ -1,25 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/secondarybackground" >
 
-    <ListView
-        android:id="@+id/messages_view"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:id="@+id/messages_refresh_view"
         android:layout_above="@+id/snackbar"
+        android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:background="@color/secondarybackground"
-        android:divider="@null"
-        android:dividerHeight="0dp"
-        android:listSelector="@android:color/transparent"
-        android:stackFromBottom="true"
-        android:transcriptMode="normal"
-        tools:listitem="@layout/message_sent" >
-    </ListView>
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
+        <ListView
+            android:id="@+id/messages_view"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/secondarybackground"
+            android:divider="@null"
+            android:dividerHeight="0dp"
+            android:listSelector="@android:color/transparent"
+            android:stackFromBottom="true"
+            android:transcriptMode="normal"
+            tools:listitem="@layout/message_sent" >
+        </ListView>
+    </android.support.v4.widget.SwipeRefreshLayout>
 
     <RelativeLayout
         android:id="@+id/textsend"


### PR DESCRIPTION
Adds a pull-to-refresh icon when loading more messages. This also gets rid of the toasts when loading MAM messages (as the loader going away is the visual cue that loading has completed, new messages or no).

The colors can be changed easily; I just used all the light material colors.

If there are no messages to load, it goes away quicker than this animation suggests; I just stuck a delay on it here so that it could actually be seen.

[![mamrender](https://cloud.githubusercontent.com/assets/512573/5929137/fe61923c-a64e-11e4-92e8-39b8a4549bd6.gif)](https://cloud.githubusercontent.com/assets/512573/5928884/afcfb06a-a64c-11e4-9184-02795f8893a4.gif)
