### PR TITLE
Removes some unused strings (the legacy SSL stuff)

### DIFF
--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -266,7 +266,6 @@
   <string name="pref_force_encryption_summary">Vždy zasílat šifrované zprávy (mimo konference)</string>
   <string name="pref_dont_save_encrypted">Neukládat šifrované zprávy</string>
   <string name="pref_dont_save_encrypted_summary">Varování: Toto může vést ke ztrátě zpráv</string>
-  <string name="pref_enable_legacy_ssl">Povolit zastaralé SSL</string>
   <string name="pref_expert_options">Expertní nastavení</string>
   <string name="pref_expert_options_summary">S tímto zacházejte velmi opatrně</string>
   <string name="title_activity_about">O aplikaci Conversations</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -266,8 +266,6 @@
   <string name="pref_force_encryption_summary">Nachrichten immer verschlüsseln (außer für Konferenzen)</string>
   <string name="pref_dont_save_encrypted">Verschlüsselte Nachrichten nicht speichern</string>
   <string name="pref_dont_save_encrypted_summary">Achtung: kann zu Nachrichtenverlust führen</string>
-  <string name="pref_enable_legacy_ssl">Alte SSL-Version aktivieren</string>
-  <string name="pref_enable_legacy_ssl_summary">Alte SSL-Version 3 und unsichere Verschlüsselungsalgorithmen aktivieren </string>
   <string name="pref_expert_options">Einstellungen für Experten</string>
   <string name="pref_expert_options_summary">Hier bitte vorsichtig sein</string>
   <string name="title_activity_about">Über Conversations</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -266,8 +266,6 @@
   <string name="pref_force_encryption_summary">Siempre enviar mensajes cifrados (excepto para conversaciones en grupo)</string>
   <string name="pref_dont_save_encrypted">No guardar mensajes cifrados</string>
   <string name="pref_dont_save_encrypted_summary">Aviso: Esto podría llevar a pérdida de mensajes</string>
-  <string name="pref_enable_legacy_ssl">Habilitar SSL heredado</string>
-  <string name="pref_enable_legacy_ssl_summary">Habilita soporte SSLv3 para servidores heredados y cifrado SSL no seguro</string>
   <string name="pref_expert_options">Ajustes avanzados</string>
   <string name="pref_expert_options_summary">Por favor, cuidado con estas opciones</string>
   <string name="title_activity_about">Acerca de Conversations</string>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -266,8 +266,6 @@
   <string name="pref_force_encryption_summary">Stuur berichten altijd versleuteld (behalve in groepsgesprekken)</string>
   <string name="pref_dont_save_encrypted">Sla versleutelde berichten niet op</string>
   <string name="pref_dont_save_encrypted_summary"><b>Waarschuwing:</b> Dit kan leiden tot verlies van berichten</string>
-  <string name="pref_enable_legacy_ssl">Sta legacy SSL toe</string>
-  <string name="pref_enable_legacy_ssl_summary">Zet legacy SSLv3-ondersteuning en onveilige SSL-versleuteling aan.</string>
   <string name="pref_expert_options">Expert-instellingen</string>
   <string name="pref_expert_options_summary">Wees voorzichtig met deze instellingen</string>
   <string name="title_activity_about">Over Conversations</string>


### PR DESCRIPTION
Remove a few unused strings (not super important; just doing some cleanup and figured that we might as well get rid of these — I thought Transifex would automatically, but I think there's been an import from it since this was removed, so I guess not).