### PR TITLE
BuildTypes in gradle to have 2 versions of Conversations in same device

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,4 +110,11 @@ android {
 
 		}
 	}
+
+    buildTypes {
+        debug {
+            applicationIdSuffix '.debug'
+            versionNameSuffix ' debug'
+        }
+    }
 }

--- a/src/debug/res/values/strings.xml
+++ b/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources>
+  <string name="app_name">Convers. debug</string>
+</resources>


### PR DESCRIPTION
With this change, when you chose debug in Build Variants windows, it's added .debug to the package name and the name of the app is Convers. debug in order to have 2 versions of the app in the same device.

![buldvariant](https://cloud.githubusercontent.com/assets/5982769/5992601/bd9e353a-aa30-11e4-9931-ed157af40d66.jpg)
![applistandroid](https://cloud.githubusercontent.com/assets/5982769/5992602/bd9f361a-aa30-11e4-9255-7109094836c9.png)

