### PR TITLE
Vitelity's s.ms service requires <body> first

### DIFF
--- a/src/main/java/eu/siacs/conversations/xmpp/stanzas/MessagePacket.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/stanzas/MessagePacket.java
@@ -26,7 +26,7 @@ public class MessagePacket extends AbstractStanza {
 		this.children.remove(findChild("body"));
 		Element body = new Element("body");
 		body.setContent(text);
-		this.children.add(body);
+		this.children.add(0, body);
 	}
 
 	public void setType(int type) {


### PR DESCRIPTION
If the <body> tag is not first, their bot just silently drops the
stanza.  I know we shouldn't have to care about order, and I'm trying to
get them to fix it, but it's not high-priority for them since "most"
clients seem to work, so I'd like this workaround in.