### PR TITLE
Add ability to specify port when creating an account

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Account.java
+++ b/src/main/java/eu/siacs/conversations/entities/Account.java
@@ -31,6 +31,8 @@ public class Account extends AbstractEntity {
 
 	public static final String USERNAME = "username";
 	public static final String SERVER = "server";
+    public static final String PORT = "port";
+    public static final String PORTSPECIFIED = "portspecified";
 	public static final String PASSWORD = "password";
 	public static final String OPTIONS = "options";
 	public static final String ROSTERVERSION = "rosterversion";
@@ -111,6 +113,8 @@ public class Account extends AbstractEntity {
 	public List<Conversation> pendingConferenceLeaves = new CopyOnWriteArrayList<>();
 	protected Jid jid;
 	protected String password;
+    protected int port = 0;
+    protected boolean portspecified = true;
 	protected int options = 0;
 	protected String rosterVersion;
 	protected State status = State.OFFLINE;
@@ -129,19 +133,21 @@ public class Account extends AbstractEntity {
 		this.uuid = "0";
 	}
 
-	public Account(final Jid jid, final String password) {
+	public Account(final Jid jid, final String password, final int port, final String portspecified) {
 		this(java.util.UUID.randomUUID().toString(), jid,
-				password, 0, null, "", null);
+				password, port, portspecified, 0, null, "", null);
 	}
 
 	public Account(final String uuid, final Jid jid,
-			final String password, final int options, final String rosterVersion, final String keys,
+			final String password, final int port, final String portspecified, final int options, final String rosterVersion, final String keys,
 			final String avatar) {
 		this.uuid = uuid;
 		this.jid = jid;
 		if (jid.isBareJid()) {
 			this.setResource("mobile");
 		}
+        this.port = port;
+        this.portspecified = Boolean.valueOf(portspecified);
 		this.password = password;
 		this.options = options;
 		this.rosterVersion = rosterVersion;
@@ -163,6 +169,8 @@ public class Account extends AbstractEntity {
 		return new Account(cursor.getString(cursor.getColumnIndex(UUID)),
 				jid,
 				cursor.getString(cursor.getColumnIndex(PASSWORD)),
+                cursor.getInt(cursor.getColumnIndex(PORT)),
+                cursor.getString(cursor.getColumnIndex(PORTSPECIFIED)),
 				cursor.getInt(cursor.getColumnIndex(OPTIONS)),
 				cursor.getString(cursor.getColumnIndex(ROSTERVERSION)),
 				cursor.getString(cursor.getColumnIndex(KEYS)),
@@ -198,12 +206,28 @@ public class Account extends AbstractEntity {
 	}
 
 	public String getPassword() {
-		return password;
-	}
+        return password;
+    }
 
-	public void setPassword(final String password) {
-		this.password = password;
-	}
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+
+    public boolean getPortSpecified() {
+        return portspecified;
+    }
+
+    public void setPortSpecified(final boolean portspecified) {
+        this.portspecified = portspecified;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(final int port) {
+        this.port = port;
+    }
 
 	public State getStatus() {
 		if (isOptionSet(OPTION_DISABLED)) {
@@ -261,6 +285,7 @@ public class Account extends AbstractEntity {
 		values.put(SERVER, jid.getDomainpart());
 		values.put(PASSWORD, password);
 		values.put(OPTIONS, options);
+        values.put(PORT, port);
 		values.put(KEYS, this.keys.toString());
 		values.put(ROSTERVERSION, rosterVersion);
 		values.put(AVATAR, avatar);

--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -45,7 +45,7 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 		db.execSQL("PRAGMA foreign_keys=ON;");
 		db.execSQL("create table " + Account.TABLENAME + "(" + Account.UUID
 				+ " TEXT PRIMARY KEY," + Account.USERNAME + " TEXT,"
-				+ Account.SERVER + " TEXT," + Account.PASSWORD + " TEXT,"
+				+ Account.SERVER + " TEXT," + Account.PORT + " NUMBER," + Account.PORTSPECIFIED + " TEXT," + Account.PASSWORD + " TEXT,"
 				+ Account.ROSTERVERSION + " TEXT," + Account.OPTIONS
 				+ " NUMBER, " + Account.AVATAR + " TEXT, " + Account.KEYS
 				+ " TEXT)");

--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -172,7 +172,12 @@ public class XmppConnection implements Runnable {
 							// TODO: Handle me?`
 							srvRecordServer = "";
 						}
-						final int srvRecordPort = namePort.getInt("port");
+                        final int srvRecordPort;
+                        if (account.getPortSpecified() == true){
+                           srvRecordPort = account.getPort();
+                        } else {
+                           srvRecordPort = namePort.getInt("port");;
+                        }
 						final String srvIpServer = namePort.getString("ip");
 						final InetSocketAddress addr;
 						if (srvIpServer != null) {
@@ -202,7 +207,7 @@ public class XmppConnection implements Runnable {
 				}
 			} else if (result.containsKey("error")
 					&& "nosrv".equals(result.getString("error", null))) {
-				socket = new Socket(account.getServer().getDomainpart(), 5222);
+				socket = new Socket(account.getServer().getDomainpart(), account.getPort());
 			} else {
 				throw new IOException("timeout in dns");
 			}

--- a/src/main/res/layout/activity_edit_account.xml
+++ b/src/main/res/layout/activity_edit_account.xml
@@ -38,74 +38,107 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
                     android:layout_toRightOf="@+id/avater">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/account_settings_jabber_id"
-                    android:textColor="@color/primarytext"
-                    android:textSize="?attr/TextSizeBody" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/account_settings_jabber_id"
+                        android:textColor="@color/primarytext"
+                        android:textSize="?attr/TextSizeBody" />
 
-                <AutoCompleteTextView
-                    android:id="@+id/account_jid"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/account_settings_example_jabber_id"
-                    android:inputType="textEmailAddress"
-                    android:textColor="@color/primarytext"
-                    android:textColorHint="@color/secondarytext"
-                    android:textSize="?attr/TextSizeBody" />
+                    <AutoCompleteTextView
+                        android:id="@+id/account_jid"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/account_settings_example_jabber_id"
+                        android:inputType="textEmailAddress"
+                        android:textColor="@color/primarytext"
+                        android:textColorHint="@color/secondarytext"
+                        android:textSize="?attr/TextSizeBody" />
 
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="@string/account_settings_password"
-                    android:textColor="@color/primarytext"
-                    android:textSize="?attr/TextSizeBody" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/account_settings_password"
+                        android:textColor="@color/primarytext"
+                        android:textSize="?attr/TextSizeBody" />
 
-                <EditText
-                    android:id="@+id/account_password"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/password"
-                    android:inputType="textPassword"
-                    android:textColor="@color/primarytext"
-                    android:textColorHint="@color/secondarytext"
-                    android:textSize="?attr/TextSizeBody" />
+                    <EditText
+                        android:id="@+id/account_password"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/password"
+                        android:inputType="textPassword"
+                        android:textColor="@color/primarytext"
+                        android:textColorHint="@color/secondarytext"
+                        android:textSize="?attr/TextSizeBody" />
 
-                <CheckBox
-                    android:id="@+id/account_register_new"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="@string/register_account"
-                    android:textColor="@color/primarytext"
-                    android:textSize="?attr/TextSizeBody" />
+                    <CheckBox
+                        android:id="@+id/account_register_new"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/register_account"
+                        android:textColor="@color/primarytext"
+                        android:textSize="?attr/TextSizeBody" />
 
-                <TextView
-                    android:id="@+id/account_confirm_password_desc"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/account_settings_confirm_password"
-                    android:textColor="@color/primarytext"
-                    android:textSize="?attr/TextSizeBody"
-                    android:visibility="gone" />
+                    <CheckBox
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/account_settings_specifyport"
+                        android:id="@+id/account_specify_port"
+                        android:enabled="true"
+                        android:checked="false"
+                        android:textColor="@color/primarytext"
+                        android:textSize="?attr/TextSizeBody" />
 
-                <EditText
-                    android:id="@+id/account_password_confirm"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:hint="@string/confirm_password"
-                    android:inputType="textPassword"
-                    android:visibility="gone"
-                    android:textColor="@color/primarytext"
-                    android:textColorHint="@color/secondarytext"
-                    android:textSize="?attr/TextSizeBody" />
+                    <TextView
+                        android:id="@+id/account_text_port"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:visibility="gone"
+                        android:text="@string/account_settings_port"
+                        android:textColor="@color/primarytext"
+                        android:textSize="?attr/TextSizeBody" />
+
+                    <EditText
+                        android:id="@+id/account_port"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/port"
+                        android:inputType="number"
+                        android:textColor="@color/primarytext"
+                        android:textColorHint="@color/secondarytext"
+                        android:text="5222"
+                        android:visibility="gone"
+                        android:textSize="?attr/TextSizeBody"
+                        android:enabled="true" />
+
+                    <TextView
+                        android:id="@+id/account_confirm_password_desc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/account_settings_confirm_password"
+                        android:textColor="@color/primarytext"
+                        android:textSize="?attr/TextSizeBody"
+                        android:visibility="gone" />
+
+                    <EditText
+                        android:id="@+id/account_password_confirm"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="@string/confirm_password"
+                        android:inputType="textPassword"
+                        android:visibility="gone"
+                        android:textColor="@color/primarytext"
+                        android:textColorHint="@color/secondarytext"
+                        android:textSize="?attr/TextSizeBody" />
                 </LinearLayout>
             </RelativeLayout>
 
-           <LinearLayout
+            <LinearLayout
                 android:id="@+id/stats"
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -166,9 +166,12 @@
     <string name="attach_record_voice">Record voice</string>
     <string name="account_settings_jabber_id">Jabber ID</string>
     <string name="account_settings_password">Password</string>
+    <string name="account_settings_port">Server Port</string>
+    <string name="account_settings_specifyport">Manually specify server port</string>
     <string name="account_settings_example_jabber_id">username@example.com</string>
     <string name="account_settings_confirm_password">Confirm password</string>
     <string name="password">Password</string>
+    <string name="port">Port</string>
     <string name="confirm_password">Confirm password</string>
     <string name="passwords_do_not_match">Passwords do not match</string>
     <string name="invalid_jid">This is not a valid Jabber ID</string>


### PR DESCRIPTION
This is a bit of a sloppy workaround but it seems to work for my purposes so far. I'll likely put some more time into it but this should be enough to get the wheels in motion for this feature.

Known issues:
- Port and specified status are not read correctly from database in Manage Accounts screen
- Backing out of a conference sometimes causes conversation list activity to redraw over and over (not sure this is related to my modifications)
- No error handling for invalid port numbers