### PR TITLE
Green led color is better with "full-green"

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -214,7 +214,7 @@ public class NotificationService {
 			mBuilder.setDefaults(0);
 			mBuilder.setSmallIcon(R.drawable.ic_notification);
 			mBuilder.setDeleteIntent(createDeleteIntent());
-			mBuilder.setLights(0xff259b24, 2000, 3000);
+			mBuilder.setLights(0xff00FF00, 2000, 3000);
 			final Notification notification = mBuilder.build();
 			notificationManager.notify(NOTIFICATION_ID, notification);
 		}


### PR DESCRIPTION
I've tried this debug version on different devices, and the led is really more like the Conversation green when set to full-green than with the Conversation's green...

Thanks !