### PR TITLE
Added multiple select to Choose Contact Activity (squashed)

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ChooseContactActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ChooseContactActivity.java
@@ -3,20 +3,100 @@ package eu.siacs.conversations.ui;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.ActionMode;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.AbsListView.MultiChoiceModeListener;
 import android.widget.AdapterView;
+import android.widget.ListView;
 
+import java.util.Set;
+import java.util.HashSet;
 import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
 
+import eu.siacs.conversations.R;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Contact;
 import eu.siacs.conversations.entities.ListItem;
 
 public class ChooseContactActivity extends AbstractSearchableListItemActivity {
+
+	private Set<Contact> selected;
+	private Set<String> filterContacts;
+
 	@Override
 	public void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		filterContacts = new HashSet<>();
+		String[] contacts = getIntent().getStringArrayExtra("filter_contacts");
+		if (contacts != null) {
+			Collections.addAll(filterContacts, contacts);
+		}
+
+		if (getIntent().getBooleanExtra("multiple", false)) {
+			getListView().setChoiceMode(ListView.CHOICE_MODE_MULTIPLE_MODAL);
+			getListView().setMultiChoiceModeListener(new MultiChoiceModeListener() {
+
+				@Override
+				public  boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+					return false;
+				}
+
+				@Override
+				public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+					final InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+					imm.hideSoftInputFromWindow(getSearchEditText().getWindowToken(),
+							InputMethodManager.HIDE_IMPLICIT_ONLY);
+					MenuInflater inflater = getMenuInflater();
+					inflater.inflate(R.menu.select_multiple, menu);
+					selected = new HashSet<Contact>();
+					return true;
+				}
+
+				@Override
+				public void onDestroyActionMode(ActionMode mode) {
+				}
+
+				@Override
+				public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+					switch(item.getItemId()) {
+						case R.id.selection_submit:
+							final Intent request = getIntent();
+							final Intent data = new Intent();
+							data.putExtra("conversation",
+									request.getStringExtra("conversation"));
+							String[] selection = getSelectedContactJids();
+							data.putExtra("contacts", selection);
+							data.putExtra("multiple", true);
+							setResult(RESULT_OK, data);
+							finish();
+							return true;
+					}
+					return false;
+				}
+
+				@Override
+				public void onItemCheckedStateChanged(ActionMode mode, int position, long id, boolean checked) {
+					Contact item = (Contact) getListItems().get(position);
+					if (checked) {
+						selected.add(item);
+					} else {
+						selected.remove(item);
+					}
+					int numSelected = selected.size();
+					MenuItem selectButton = mode.getMenu().findItem(R.id.selection_submit);
+					String buttonText = getResources().getQuantityString(R.plurals.select_contact,
+							numSelected, numSelected);
+					selectButton.setTitle(buttonText);
+				}
+			});
+		}
+
 		getListView().setOnItemClickListener(new AdapterView.OnItemClickListener() {
 
 			@Override
@@ -36,6 +116,7 @@ public class ChooseContactActivity extends AbstractSearchableListItemActivity {
 				data.putExtra("account", account);
 				data.putExtra("conversation",
 						request.getStringExtra("conversation"));
+				data.putExtra("multiple", false);
 				setResult(RESULT_OK, data);
 				finish();
 			}
@@ -48,7 +129,9 @@ public class ChooseContactActivity extends AbstractSearchableListItemActivity {
 		for (final Account account : xmppConnectionService.getAccounts()) {
 			if (account.getStatus() != Account.State.DISABLED) {
 				for (final Contact contact : account.getRoster().getContacts()) {
-					if (contact.showInRoster() && contact.match(needle)) {
+					if (contact.showInRoster() &&
+							!filterContacts.contains(contact.getJid().toBareJid().toString())
+							&& contact.match(needle)) {
 						getListItems().add(contact);
 					}
 				}
@@ -57,4 +140,13 @@ public class ChooseContactActivity extends AbstractSearchableListItemActivity {
 		Collections.sort(getListItems());
 		getListItemAdapter().notifyDataSetChanged();
 	}
+
+	private String[] getSelectedContactJids() {
+		List<String> result = new ArrayList<>();
+		for (Contact contact : selected) {
+			result.add(contact.getJid().toString());
+		}
+		return result.toArray(new String[result.size()]);
+	}
+
 }

--- a/src/main/res/menu/select_multiple.xml
+++ b/src/main/res/menu/select_multiple.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item
+        android:id="@+id/selection_submit"
+        android:title="@string/invite_contact"
+        android:showAsAction="always" />
+
+</menu>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -454,4 +454,8 @@
     <string name="no_application_found_to_display_location">No application found to display location</string>
     <string name="location">Location</string>
     <string name="received_location">Received location</string>
+	<plurals name="select_contact">
+		<item quantity="one">Select %d contact</item>
+		<item quantity="other">Select %d contacts</item>
+	</plurals>
 </resources>


### PR DESCRIPTION
When passing the Choose Contact Activity a boolean called "multiple"
set to true, it now allows the user to select multiple contacts. Long
pressing a contact enters multiple selection mode and the selection is
confirmed using a button in the CAB. The Activity returns whether or not
multiple contacts were selected using the same boolean. If multiple
contacts were selected, an array of JID strings called "contacts" is
returned. The Choose Contact Activity now also honors "filter_contacts",
an array of strings containing JIDs that should not be displayed in
the picker.

The invite to conference dialog now uses this feature to enable inviting
multiple contacts at once. Additionally, Invite Contact uses
"filter_contacts" to only display contacts that are not yet
participating in the conversation