### PR TITLE
Offer itself as SMS application for sharing (Issue #1050)

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -116,6 +116,13 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="vnd.android-dir/mms-sms" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.SEND" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/src/main/java/eu/siacs/conversations/ui/ShareWithActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ShareWithActivity.java
@@ -135,7 +135,12 @@ public class ShareWithActivity extends XmppActivity {
 	public void onStart() {
 		final String type = getIntent().getType();
 		final Uri uri = getIntent().getParcelableExtra(Intent.EXTRA_STREAM);
-		if (type != null && uri != null && !type.equalsIgnoreCase("text/plain")) {
+		if (type != null && type.equalsIgnoreCase("vnd.android-dir/mms-sms")) {
+			final Bundle b = getIntent().getExtras();
+			if (b != null) {
+				this.share.text = "" + b.get("sms_body");
+			}
+		} else if (type != null && uri != null && !type.equalsIgnoreCase("text/plain")) {
 			this.share.uri = uri;
 			this.share.image = type.startsWith("image/") || isImage(uri);
 		} else {


### PR DESCRIPTION
Changes as proposed in issue #1050 
I'am afraid I did not understand the comment of TameOfGroans 
> consider referring to sms as "sms texting" and xmpp as "xmpp texting". 
This will help ease the transition.

So his suggestions is not taken into account up to now.