### PR TITLE
Add toggle account-state switch

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ManageAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ManageAccountActivity.java
@@ -168,6 +168,14 @@ public class ManageAccountActivity extends XmppActivity implements OnAccountUpda
 		}
 	}
 
+	public void onClickTglAccountState(Account account) {
+		if (account.isOptionSet(Account.OPTION_DISABLED)) {
+			enableAccount(account);
+		} else {
+			disableAccount(account);
+		}
+	}
+
 	private void publishAvatar(Account account) {
 		Intent intent = new Intent(getApplicationContext(),
 				PublishProfilePictureActivity.class);

--- a/src/main/java/eu/siacs/conversations/ui/adapter/AccountAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/AccountAdapter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import eu.siacs.conversations.R;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.ui.XmppActivity;
+import eu.siacs.conversations.ui.ManageAccountActivity;
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -12,6 +13,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Switch;
 
 public class AccountAdapter extends ArrayAdapter<Account> {
 
@@ -24,7 +26,7 @@ public class AccountAdapter extends ArrayAdapter<Account> {
 
 	@Override
 	public View getView(int position, View view, ViewGroup parent) {
-		Account account = getItem(position);
+		final Account account = getItem(position);
 		if (view == null) {
 			LayoutInflater inflater = (LayoutInflater) getContext()
 					.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
@@ -34,21 +36,32 @@ public class AccountAdapter extends ArrayAdapter<Account> {
 		jid.setText(account.getJid().toBareJid().toString());
 		TextView statusView = (TextView) view.findViewById(R.id.account_status);
 		ImageView imageView = (ImageView) view.findViewById(R.id.account_image);
-		imageView.setImageBitmap(activity.avatarService().get(account,
-				activity.getPixel(48)));
-        statusView.setText(getContext().getString(account.getStatus().getReadableId()));
-        switch (account.getStatus()) {
-            case ONLINE:
-                statusView.setTextColor(activity.getOnlineColor());
-                break;
-            case DISABLED:
-            case CONNECTING:
-                statusView.setTextColor(activity.getSecondaryTextColor());
-                break;
-            default:
-                statusView.setTextColor(activity.getWarningTextColor());
-                break;
-        }
+		imageView.setImageBitmap(activity.avatarService().get(account, activity.getPixel(48)));
+		statusView.setText(getContext().getString(account.getStatus().getReadableId()));
+		switch (account.getStatus()) {
+			case ONLINE:
+				statusView.setTextColor(activity.getOnlineColor());
+				break;
+			case DISABLED:
+			case CONNECTING:
+				statusView.setTextColor(activity.getSecondaryTextColor());
+				break;
+			default:
+				statusView.setTextColor(activity.getWarningTextColor());
+				break;
+		}
+		final Switch tglAccountState = (Switch) view.findViewById(R.id.tgl_account_status);
+		boolean isDisabled = (account.getStatus() == Account.State.DISABLED) ? true : false;
+		tglAccountState.setChecked(!isDisabled);
+		tglAccountState.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				if (activity instanceof ManageAccountActivity) {
+					((ManageAccountActivity) activity).onClickTglAccountState(account);
+					tglAccountState.toggle();
+				}
+			}
+		});
 		return view;
 	}
 }

--- a/src/main/res/layout/account_row.xml
+++ b/src/main/res/layout/account_row.xml
@@ -41,4 +41,12 @@
             android:textStyle="bold" />
     </LinearLayout>
 
+    <Switch
+        android:id="@+id/tgl_account_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:focusable="false"/>
+
 </RelativeLayout>


### PR DESCRIPTION
While I like the context-menu approach in general it can be somewhat tedious to enable/disable multiple but not all accounts. The added switch allows to toggle an account state from the ManageAccountActivity directly.