### PR TITLE
Add a ContextMenu to ConversationsActivity

### DIFF
--- a/src/main/res/menu/conversations_context.xml
+++ b/src/main/res/menu/conversations_context.xml
@@ -1,0 +1,28 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+
+	<item
+		android:id="@+id/action_contact_details"
+		android:orderInCategory="10"
+		android:title="@string/action_contact_details"/>
+	<item
+		android:id="@+id/action_muc_details"
+		android:orderInCategory="20"
+		android:title="@string/action_muc_details"/>
+	<item
+		android:id="@+id/action_archive"
+		android:orderInCategory="30"
+		android:title="@string/action_end_conversation"/>
+	<item
+		android:id="@+id/action_mute"
+		android:orderInCategory="40"
+		android:title="@string/disable_notifications"/>
+	<item
+		android:id="@+id/action_unmute"
+		android:orderInCategory="41"
+		android:title="@string/enable_notifications"/>
+	<item
+		android:id="@+id/action_clear_history"
+		android:orderInCategory="50"
+		android:title="@string/action_clear_history"/>
+
+</menu>


### PR DESCRIPTION
I'd like to propose a context menu for the main ConversationsActivity.
A long press on one of the active conversations brings up a menu with direct acces to conversation-specific options like end conversation, contact details and so on. 