### PR TITLE
Fix OTR-Error messages (#1021)

### DIFF
--- a/src/main/java/eu/siacs/conversations/crypto/OtrEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/OtrEngine.java
@@ -202,20 +202,7 @@ public class OtrEngine extends OtrCryptoEngineImpl implements OtrEngineHost {
 
 	@Override
 	public void messageFromAnotherInstanceReceived(SessionID session) {
-		try {
-			Jid jid = Jid.fromSessionID(session);
-			Conversation conversation = mXmppConnectionService.find(account, jid);
-			String id = conversation == null ? null : conversation.getLastReceivedOtrMessageId();
-			if (id != null) {
-				MessagePacket packet = mXmppConnectionService.getMessageGenerator().generateOtrError(jid,id);
-				packet.setFrom(account.getJid());
-				mXmppConnectionService.sendMessagePacket(account,packet);
-				Log.d(Config.LOGTAG,packet.toString());
-				Log.d(Config.LOGTAG,account.getJid().toBareJid().toString()+": unreadable OTR message in "+conversation.getName());
-			}
-		} catch (InvalidJidException e) {
-			return;
-		}
+		sendOtrErrorMessage(session, "Message from another OTR-instance received");
 	}
 
 	@Override
@@ -267,9 +254,28 @@ public class OtrEngine extends OtrCryptoEngineImpl implements OtrEngineHost {
 	}
 
 	@Override
-	public void unreadableMessageReceived(SessionID arg0) throws OtrException {
+	public void unreadableMessageReceived(SessionID session) throws OtrException {
 		Log.d(Config.LOGTAG,"unreadable message received");
-		throw new OtrException(new Exception("unreadable message received"));
+		sendOtrErrorMessage(session, "You sent me an unreadable OTR-encrypted message");
+	}
+
+	public void sendOtrErrorMessage(SessionID session, String errorText) {
+		try {
+			Jid jid = Jid.fromSessionID(session);
+			Conversation conversation = mXmppConnectionService.find(account, jid);
+			String id = conversation == null ? null : conversation.getLastReceivedOtrMessageId();
+			if (id != null) {
+				MessagePacket packet = mXmppConnectionService.getMessageGenerator()
+						.generateOtrError(jid, id, errorText);
+				packet.setFrom(account.getJid());
+				mXmppConnectionService.sendMessagePacket(account,packet);
+				Log.d(Config.LOGTAG,packet.toString());
+				Log.d(Config.LOGTAG,account.getJid().toBareJid().toString()
+						+": unreadable OTR message in "+conversation.getName());
+			}
+		} catch (InvalidJidException e) {
+			return;
+		}
 	}
 
 	@Override

--- a/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
+++ b/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
@@ -172,7 +172,7 @@ public class MessageGenerator extends AbstractGenerator {
 		return receivedPacket;
 	}
 
-	public MessagePacket generateOtrError(Jid to, String id) {
+	public MessagePacket generateOtrError(Jid to, String id, String errorText) {
 		MessagePacket packet = new MessagePacket();
 		packet.setType(MessagePacket.TYPE_ERROR);
 		packet.setAttribute("id",id);
@@ -181,7 +181,7 @@ public class MessageGenerator extends AbstractGenerator {
 		error.setAttribute("code","406");
 		error.setAttribute("type","modify");
 		error.addChild("not-acceptable","urn:ietf:params:xml:ns:xmpp-stanzas");
-		error.addChild("text").setContent("unreadable OTR message received");
+		error.addChild("text").setContent("?OTR Error:" + errorText);
 		return packet;
 	}
 }


### PR DESCRIPTION
The current patch for https://github.com/siacs/Conversations/issues/1021 only sends out an error message on receival of unreadable messages from other OTR-Instances.
This patch tries to also inform the sender when the recipient already discarded session-keys the sender is still using.
I am still uncertain whether its a good idea to send a XMPP error-message but I attempted to stick to the approach you chose in https://github.com/siacs/Conversations/commit/99b2ef7e9d571dcfa386df4d0190ce626e657232
Please also see my comment in https://github.com/siacs/Conversations/issues/1021 in this regard.