### PR TITLE
Add option to use MTM without default TrustManager (#1084)

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -532,9 +532,7 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 		ExceptionHelper.init(getApplicationContext());
 		PRNGFixes.apply();
 		this.mRandom = new SecureRandom();
-		this.mMemorizingTrustManager = new MemorizingTrustManager(
-				getApplicationContext());
-
+		updateMemorizingTrustmanager();
 		final int maxMemory = (int) (Runtime.getRuntime().maxMemory() / 1024);
 		final int cacheSize = maxMemory / 8;
 		this.mBitmapCache = new LruCache<String, Bitmap>(cacheSize) {
@@ -2183,6 +2181,21 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 
 	public MemorizingTrustManager getMemorizingTrustManager() {
 		return this.mMemorizingTrustManager;
+	}
+
+	public void setMemorizingTrustManager(MemorizingTrustManager trustManager) {
+		this.mMemorizingTrustManager = trustManager;
+	}
+
+	public void updateMemorizingTrustmanager() {
+		final MemorizingTrustManager tm;
+		final boolean dontTrustSystemCAs = getPreferences().getBoolean("dont_trust_system_cas", false);
+		if (dontTrustSystemCAs) {
+			 tm = new MemorizingTrustManager(getApplicationContext(), null);
+		} else {
+			tm = new MemorizingTrustManager(getApplicationContext());
+		}
+		setMemorizingTrustManager(tm);
 	}
 
 	public PowerManager getPowerManager() {

--- a/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
@@ -79,7 +79,8 @@ public class SettingsActivity extends XmppActivity implements
 					}
 				}
 			}
+		} else if (name.equals("dont_trust_system_cas")) {
+			xmppConnectionService.updateMemorizingTrustmanager();
 		}
 	}
-
 }

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -427,6 +427,8 @@
   <string name="no_application_found_to_display_location">Keine App für die Standort-Anzeige gefunden</string>
   <string name="location">Standort</string>
   <string name="received_location">Standort empfangen</string>
+  <string name="pref_dont_trust_system_cas_title">Misstraue Zertifizierungsstellen</string>
+  <string name="pref_dont_trust_system_cas_summary">Alle Zertifikate müssen manuell bestätigt werden</string>
   <plurals name="select_contact">
     <item quantity="one">%d Kontakt ausgewählt</item>
     <item quantity="other">%d Kontakte ausgewählt</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -454,6 +454,8 @@
     <string name="no_application_found_to_display_location">No application found to display location</string>
     <string name="location">Location</string>
     <string name="received_location">Received location</string>
+	<string name="pref_dont_trust_system_cas_title">Don\'t trust system CAs</string>
+	<string name="pref_dont_trust_system_cas_summary">All certificates must be manually approved</string>
 	<plurals name="select_contact">
 		<item quantity="one">Select %d contact</item>
 		<item quantity="other">Select %d contacts</item>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -147,6 +147,11 @@
                     android:key="keep_foreground_service"
                     android:title="@string/pref_keep_foreground_service"
                     android:summary="@string/pref_keep_foreground_service_summary" />
+				<CheckBoxPreference
+					android:defaultValue="false"
+					android:key="dont_trust_system_cas"
+					android:title="@string/pref_dont_trust_system_cas_title"
+					android:summary="@string/pref_dont_trust_system_cas_summary" />
             </PreferenceCategory>
         </PreferenceScreen>
 


### PR DESCRIPTION
Attempt to fix #1084 by adding a new "Don't trust system CAs" preference under advanced options
that will change the behaviour of the MemorizingTrustManager. All formerly unknown certificates will raise a warning if checked. 
Please review and test carefully.