### PR TITLE
OTR: Fix onContactStatusChanged & dont archive OTR

### DIFF
--- a/src/main/java/eu/siacs/conversations/crypto/OtrEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/OtrEngine.java
@@ -182,7 +182,7 @@ public class OtrEngine extends OtrCryptoEngineImpl implements OtrEngineHost {
 		packet.setBody(body);
 		packet.addChild("private", "urn:xmpp:carbons:2");
 		packet.addChild("no-copy", "urn:xmpp:hints");
-		packet.addChild("no-store", "urn:xmpp:hints");
+		packet.addChild("no-permanent-store", "urn:xmpp:hints");
 
 		try {
 			Jid jid = Jid.fromSessionID(session);

--- a/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
+++ b/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
@@ -71,6 +71,7 @@ public class MessageGenerator extends AbstractGenerator {
 		MessagePacket packet = preparePacket(message, addDelay);
 		packet.addChild("private", "urn:xmpp:carbons:2");
 		packet.addChild("no-copy", "urn:xmpp:hints");
+		packet.addChild("no-permanent-store", "urn:xmpp:hints");
 		try {
 			packet.setBody(otrSession.transformSending(message.getBody())[0]);
 			return packet;


### PR DESCRIPTION
- Fix session handling on contact status change: Do not reset
  potentially active sessions; check peer's OTR-resource on disconnect
- use no-permanent-store hint instead of no-store to ensure
  finished-messages are delivered to offline/disconnected clients
- add no-permanent-store to ask compliant servers not to archive
  OTR messages

-
Further notes:
- If a contact is connected with several clients and disconnects with the OTR enabled client, that client will sometimes be listed in the resource dialog when I try to directly start a new OTR session. Haven't yet checked why and when this is the case, though.
- The Padlock symbol in the ActionBar is currently not updated on reception of an OTR finished message. Can we safely change line 375 in ConversationActivity from
`if this.getSelectedConversation().getLatestMessage().getEncryption() != [...]`to `if (this.getSelectedConversation().getNextEncryption(false) != [...]` to always reflect the mode for the next message or could this cause unwanted side effects (e.g., for PGP)?
- I think the switch from OTR to plaintext when the peer sent a finished message should be highlighted - when force encryption is not active it's sometimes hard to spot that the OTR session has been closed. What do you think about another SnackBar for this case?

After digging through most of the OTR-related code I think it'd be worth to consider maintaining sessions as long as possible - that is, only end sessions when the user logs out. This seems to be the approach ChatSecure and Xabber use and they do quite reliably so. This could massively decrease the message-overhead caused by KE messages and might also reduce code complexity to a certain degree.  