### PR TITLE
changed 'checking_image' to 'checking_file'

### DIFF
--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -145,7 +145,7 @@ public class UIHelper {
 		if (d != null ) {
 			switch (d.getStatus()) {
 				case Transferable.STATUS_CHECKING:
-					return new Pair<>(context.getString(R.string.checking_image),true);
+					return new Pair<>(context.getString(R.string.checking_file),true);
 				case Transferable.STATUS_DOWNLOADING:
 					return new Pair<>(context.getString(R.string.receiving_x_file,
 									getFileDescriptionString(context,message),

--- a/src/main/res/values-bg/strings.xml
+++ b/src/main/res/values-bg/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Тази беседа е само за членове</string>
   <string name="conference_kicked">Бяхте изритан от тази конференция</string>
   <string name="using_account">използвайки профила %s</string>
-  <string name="checking_image">Проверяване на изображението на HTTP сървъра</string>
+  <string name="checking_file">Проверяване на изображението на HTTP сървъра</string>
   <string name="image_file_deleted">Изображението е изтрито</string>
   <string name="not_connected_try_again">Не сте свързани. Опитайте отново по-късно</string>
   <string name="check_image_filesize">Проверка на размера на файла с изображението</string>

--- a/src/main/res/values-ca/strings.xml
+++ b/src/main/res/values-ca/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">La sala es nomès per membres</string>
   <string name="conference_kicked">Estàs expulsat d\'aquesta sala</string>
   <string name="using_account">Utlitzant el compte %s</string>
-  <string name="checking_image">Comprovant l\'imatge en el client HTTP</string>
+  <string name="checking_file">Comprovant l\'imatge en el client HTTP</string>
   <string name="image_file_deleted">L\'arxiu de l\'imatge ha sigut eliminada</string>
   <string name="not_connected_try_again">No estàs connectat. Intenta-ho més tard</string>
   <string name="check_image_filesize">Comprobant el tamany de l\'imatge</string>

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Tato konference je pouze pro členy</string>
   <string name="conference_kicked">Vykopli tě z této konference</string>
   <string name="using_account">za použití účtu %s</string>
-  <string name="checking_image">Ověřuji obrázek na HTTP hostiteli</string>
+  <string name="checking_file">Ověřuji obrázek na HTTP hostiteli</string>
   <string name="image_file_deleted">Obrázek byl smazán</string>
   <string name="not_connected_try_again">Bez připojení. Zkus znovu později</string>
   <string name="check_image_filesize">Ověřit velikost obrázku</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Die Konferenz ist nur für Mitglieder</string>
   <string name="conference_kicked">Du wurdest aus der Konferenz geworfen</string>
   <string name="using_account">Verwende Konto %s</string>
-  <string name="checking_image">Prüfe Bild auf HTTP-Host</string>
+  <string name="checking_file">Prüfe Datei auf HTTP-Host</string>
   <string name="image_file_deleted">Bild wurde gelöscht</string>
   <string name="not_connected_try_again">Nicht verbunden, bitte später versuchen</string>
   <string name="check_image_filesize">Bildgröße prüfen</string>

--- a/src/main/res/values-el/strings.xml
+++ b/src/main/res/values-el/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Αυτή η συνδιάσκεψη είναι μόνο για μέλη</string>
   <string name="conference_kicked">Έχετε διωχθει από αυτή την συνδιάσκεψη</string>
   <string name="using_account">χρήση λογαριασμού %s</string>
-  <string name="checking_image">Έλεγχος εικόνας στον διακομιστή HTTP</string>
+  <string name="checking_file">Έλεγχος εικόνας στον διακομιστή HTTP</string>
   <string name="image_file_deleted">Το αρχείο εικόνας έχει διαγραφεί</string>
   <string name="not_connected_try_again">Δεν είστε συνδεμένοι. Δοκιμάστε ξανά αργότερα</string>
   <string name="check_image_filesize">Ελέγξτε το μέγεθος του αρχείου εικόνας</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Esta conversación es solo para miembros</string>
   <string name="conference_kicked">Has sido expulsado de esta conversación</string>
   <string name="using_account">Usando cuenta %s</string>
-  <string name="checking_image">Comprobando imagen en servidor HTTP</string>
+  <string name="checking_file">Comprobando imagen en servidor HTTP</string>
   <string name="image_file_deleted">El archivo de imagen ha sido eliminado</string>
   <string name="not_connected_try_again">No estás conectado. Inténtalo más tarde</string>
   <string name="check_image_filesize">Comprobar el tamaño del archivo de imagen</string>

--- a/src/main/res/values-eu/strings.xml
+++ b/src/main/res/values-eu/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Konferentzia hau kideentzat da soilik</string>
   <string name="conference_kicked">Konferentzia honetatik kanporatua izan zara</string>
   <string name="using_account">%s kontua erabiltzen</string>
-  <string name="checking_image">Irudia egiaztatzen HTTP ostalarian</string>
+  <string name="checking_file">Irudia egiaztatzen HTTP ostalarian</string>
   <string name="image_file_deleted">Irudia ezabatu egin da</string>
   <string name="not_connected_try_again">Ez zaude konektatuta. Saiatu beranduago berriz</string>
   <string name="check_image_filesize">Irudiaren tamaina egiaztatu</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Cette conférence est réservée aux membres</string>
   <string name="conference_kicked">Vous avez été éjecté de cette conférence</string>
   <string name="using_account">utiliser le compte %s</string>
-  <string name="checking_image">Vérification de l\'image</string>
+  <string name="checking_file">Vérification de l\'image</string>
   <string name="image_file_deleted">L\'image a été suprimée</string>
   <string name="not_connected_try_again">Vous n\'êtes pas connecté. Merci de retenter plus tard.</string>
   <string name="check_image_filesize">Vérifier la taille de l\'image</string>

--- a/src/main/res/values-id/strings.xml
+++ b/src/main/res/values-id/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Conference ini hanya untuk member terdaftar</string>
   <string name="conference_kicked">Anda telah ditendang dari conference ini</string>
   <string name="using_account">menggunakan akun %s</string>
-  <string name="checking_image">Mengecek gambar di host HTTP</string>
+  <string name="checking_file">Mengecek gambar di host HTTP</string>
   <string name="image_file_deleted">Berkas gambar telah dihapus</string>
   <string name="not_connected_try_again">Anda tidak terhubung. Coba lagi nanti</string>
   <string name="check_image_filesize">Cek ukuran berkas gambar</string>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Questa conferenza è solo per membri</string>
   <string name="conference_kicked">Sei stato buttato fuori dalla conferenza</string>
   <string name="using_account">usando l’utente %s</string>
-  <string name="checking_image">Controlla immagine su HTTP</string>
+  <string name="checking_file">Controlla immagine su HTTP</string>
   <string name="image_file_deleted">Il file dell’immagine è stato cancellato</string>
   <string name="not_connected_try_again">Non sei connesso. Riprova più tardi</string>
   <string name="check_image_filesize">Controlla le dimensioni dell’immagine</string>

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">この会議はメンバーのみです</string>
   <string name="conference_kicked">あなたはこの会議からキックされました</string>
   <string name="using_account">アカウント %s を使用</string>
-  <string name="checking_image">HTTP ホストの画像を確認中</string>
+  <string name="checking_file">HTTP ホストの画像を確認中</string>
   <string name="image_file_deleted">画像ファイルは削除されました</string>
   <string name="not_connected_try_again">接続されていません。後でもう一度お試しください</string>
   <string name="check_image_filesize">画像ファイルのサイズを確認</string>

--- a/src/main/res/values-ko/strings.xml
+++ b/src/main/res/values-ko/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">이 회의는 멤버 전용입니다 </string>
   <string name="conference_kicked">당신은 이 회의에서 추방되었습니다  </string>
   <string name="using_account">using account %s</string>
-  <string name="checking_image">HTTP 호스트에서 이미지 확인중 </string>
+  <string name="checking_file">HTTP 호스트에서 이미지 확인중 </string>
   <string name="image_file_deleted">이미지 파일이 삭제되었습니다 </string>
   <string name="not_connected_try_again">접속중이 아닙니다. 다시 시도하세요. </string>
   <string name="check_image_filesize">이미지 파일 크기 확인 </string>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Dit groepsgesprek is enkel voor leden</string>
   <string name="conference_kicked">Je bent uit dit groepsgesprek geschopt</string>
   <string name="using_account">account %s gebruiken</string>
-  <string name="checking_image">Afbeelding op HTTP host nakijken</string>
+  <string name="checking_file">Afbeelding op HTTP host nakijken</string>
   <string name="image_file_deleted">De afbeelding is verwijderd</string>
   <string name="not_connected_try_again">Je bent niet verbonden. Probeer later opnieuw</string>
   <string name="check_image_filesize">Bekijk bestandsgrootte van afbeelding</string>

--- a/src/main/res/values-pl/strings.xml
+++ b/src/main/res/values-pl/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">To jest zamknięty pokój</string>
   <string name="conference_kicked">Wyrzucono cię z konferencji</string>
   <string name="using_account">używając konta %s</string>
-  <string name="checking_image">Sprawdzanie obrazka na hoście HTTP</string>
+  <string name="checking_file">Sprawdzanie obrazka na hoście HTTP</string>
   <string name="image_file_deleted">Obraz został usunięty</string>
   <string name="not_connected_try_again">Brak połączenia. Spróbuj ponownie później</string>
   <string name="check_image_filesize">Sprawdź rozmiar pliku</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Эта конференция требует членства</string>
   <string name="conference_kicked">Вы были удалены из конференции</string>
   <string name="using_account">использовать учётную запись %s</string>
-  <string name="checking_image">Проверка изображения на узле HTTP</string>
+  <string name="checking_file">Проверка изображения на узле HTTP</string>
   <string name="image_file_deleted">Файл изображения был удалён</string>
   <string name="not_connected_try_again">Вы неподключены. Попробуйте позже</string>
   <string name="check_image_filesize">Проверить размер файла изображения</string>

--- a/src/main/res/values-sk/strings.xml
+++ b/src/main/res/values-sk/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Táto konverzácia je iba pre členov</string>
   <string name="conference_kicked">Vyčlenili vás z tejto konverzácie</string>
   <string name="using_account">Používa sa účet %s</string>
-  <string name="checking_image">Overuje sa obrázok na serveri HTTP</string>
+  <string name="checking_file">Overuje sa obrázok na serveri HTTP</string>
   <string name="image_file_deleted">Súbor s obrázkom bol vymazaný</string>
   <string name="not_connected_try_again">Nie ste pripojený. Skúste to neskôr</string>
   <string name="check_image_filesize">Overiť veľkosť obrázku</string>

--- a/src/main/res/values-sr/strings.xml
+++ b/src/main/res/values-sr/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Ова конференција је само за чланове</string>
   <string name="conference_kicked">Шутнути сте из ове конференције</string>
   <string name="using_account">преко налога %s</string>
-  <string name="checking_image">Проверавам слику на ХТТП домаћину</string>
+  <string name="checking_file">Проверавам слику на ХТТП домаћину</string>
   <string name="image_file_deleted">Ова слика је обрисана</string>
   <string name="not_connected_try_again">Нисте повезани. Покушајте поново касније</string>
   <string name="check_image_filesize">Провери величину слике</string>

--- a/src/main/res/values-sv/strings.xml
+++ b/src/main/res/values-sv/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">Medlemsskap krävs för denna konferens</string>
   <string name="conference_kicked">Du har blivit utsparkad från denna konferens</string>
   <string name="using_account">använder konto %s</string>
-  <string name="checking_image">Kontrollerar bild på HTTP host</string>
+  <string name="checking_file">Kontrollerar bild på HTTP host</string>
   <string name="image_file_deleted">Bildfilen har blivit borttagen</string>
   <string name="not_connected_try_again">Du är inte ansluten. Försök igen senare</string>
   <string name="check_image_filesize">Kontrollera bildens filstorlek</string>

--- a/src/main/res/values-zh-rCN/strings.xml
+++ b/src/main/res/values-zh-rCN/strings.xml
@@ -289,7 +289,7 @@
   <string name="conference_members_only">此讨论组只允许成员加入</string>
   <string name="conference_kicked">你被从此讨论组踢出</string>
   <string name="using_account">用账户  %s</string>
-  <string name="checking_image">正在 HTTP 托管中检查图片</string>
+  <string name="checking_file">正在 HTTP 托管中检查图片</string>
   <string name="image_file_deleted">此图片已经被删除</string>
   <string name="not_connected_try_again">你没有连接。请稍后重试</string>
   <string name="check_image_filesize">检查图片文件尺寸</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -316,7 +316,7 @@
 	<string name="conference_members_only">This conference is members only</string>
 	<string name="conference_kicked">You have been kicked from this conference</string>
 	<string name="using_account">using account %s</string>
-	<string name="checking_image">Checking image on HTTP host</string>
+	<string name="checking_file">Checking file on HTTP host</string>
 	<string name="image_file_deleted">The image file has been deleted</string>
 	<string name="not_connected_try_again">You are not connected. Try again later</string>
 	<string name="check_x_filesize">Check %s size</string>


### PR DESCRIPTION
while checking the file on a remote host, Conversations always shows: "checking image on HTTP host" although the files are no images
* language files in English and German are already corrected
* other languages need to be modified to match this changes