### PR TITLE
Fixed broken URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ decrypting and encrypting takes longer than OTR. It is however asynchronous and
 works well with message carbons.
 
 To use OpenPGP you have to install the open source app
-[OpenKeychain](www.openkeychain.org) and then long press on the account in
+[OpenKeychain](http://www.openkeychain.org) and then long press on the account in
 manage accounts and choose renew PGP announcement from the contextual menu.
 
 #### How does the encryption for conferences work?


### PR DESCRIPTION
The HTTPS server is throwing GitHub's certificate instead of a proper one, so I'm going to stick with HTTP for now.