### PR TITLE
Preference to backup logs to SD card

### DIFF
--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -21,6 +21,7 @@ import org.whispersystems.libaxolotl.state.SignedPreKeyRecord;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -380,6 +381,43 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 		}
 		cursor.close();
 		return list;
+	}
+
+	public Iterable<Message> getMessagesIterable(final Conversation conversation){
+		return new Iterable<Message>() {
+			@Override
+			public Iterator<Message> iterator() {
+				class MessageIterator implements Iterator<Message>{
+					SQLiteDatabase db = getReadableDatabase();
+					String[] selectionArgs = { conversation.getUuid() };
+					Cursor cursor = db.query(Message.TABLENAME, null, Message.CONVERSATION
+							+ "=?", selectionArgs, null, null, Message.TIME_SENT
+							+ " ASC", null);
+
+					public MessageIterator() {
+						cursor.moveToFirst();
+					}
+
+					@Override
+					public boolean hasNext() {
+						return !cursor.isAfterLast();
+					}
+
+					@Override
+					public Message next() {
+						Message message = Message.fromCursor(cursor);
+						cursor.moveToNext();
+						return message;
+					}
+
+					@Override
+					public void remove() {
+						throw new UnsupportedOperationException();
+					}
+				}
+				return new MessageIterator();
+			}
+		};
 	}
 
 	public Conversation findConversation(final Account account, final Jid contactJid) {

--- a/src/main/java/eu/siacs/conversations/ui/ExportLogsPreference.java
+++ b/src/main/java/eu/siacs/conversations/ui/ExportLogsPreference.java
@@ -119,6 +119,8 @@ public class ExportLogsPreference extends Preference {
                                 jid = getMessageCounterpart(message);
                                 break;
                             case Message.STATUS_SEND:
+                            case Message.STATUS_SEND_RECEIVED:
+                            case Message.STATUS_SEND_DISPLAYED:
                                 jid = accountJid.toBareJid().toString();
                                 break;
                         }

--- a/src/main/java/eu/siacs/conversations/ui/ExportLogsPreference.java
+++ b/src/main/java/eu/siacs/conversations/ui/ExportLogsPreference.java
@@ -1,0 +1,175 @@
+package eu.siacs.conversations.ui;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.preference.Preference;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ProgressBar;
+
+import eu.siacs.conversations.R;
+import eu.siacs.conversations.entities.Account;
+import eu.siacs.conversations.entities.Conversation;
+import eu.siacs.conversations.entities.Message;
+import eu.siacs.conversations.persistance.DatabaseBackend;
+import eu.siacs.conversations.persistance.FileBackend;
+import eu.siacs.conversations.xmpp.jid.Jid;
+
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class ExportLogsPreference extends Preference {
+    private static final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    private ProgressBar progressBar = null;
+    private ExportLogsTask exportLogsTask = null;
+    private int currentProgressBarProgress = -1;
+    private int currentProgressBarMax = -1;
+
+    public ExportLogsPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public ExportLogsPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ExportLogsPreference(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected View onCreateView(ViewGroup parent) {
+        LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        View view = inflater.inflate(R.layout.preference_export_logs, parent, false);
+        progressBar = (ProgressBar) view.findViewById(R.id.progress_bar);
+        if (exportLogsTask != null && exportLogsTask.getStatus() == AsyncTask.Status.RUNNING) {
+            progressBar.setMax(currentProgressBarMax);
+            progressBar.setProgress(currentProgressBarProgress);
+            progressBar.setVisibility(View.VISIBLE);
+        } else {
+            progressBar.setVisibility(View.INVISIBLE);
+        }
+        return view;
+    }
+
+    protected void onClick() {
+        if (exportLogsTask == null || exportLogsTask.getStatus() == AsyncTask.Status.FINISHED) {
+            exportLogsTask = new ExportLogsTask();
+            exportLogsTask.execute();
+        }
+    }
+
+    private void setProgressBarProgress(int progress) {
+        currentProgressBarProgress = progress;
+        progressBar.setProgress(progress);
+    }
+
+    private void setProgressBarMax(int max) {
+        currentProgressBarMax = max;
+        progressBar.setMax(max);
+    }
+
+    private class ExportLogsTask extends AsyncTask<Void, Integer, Void> {
+
+        final String DIRECTORY_STRING_FORMAT = FileBackend.getConversationsFileDirectory() + "/logs/%s/%s";
+        final String MESSAGE_STRING_FORMAT = "(%s) %s: %s\n";
+
+        DatabaseBackend databaseBackend = DatabaseBackend.getInstance(getContext());
+        List<Account> accounts = databaseBackend.getAccounts();
+
+        protected Void doInBackground(Void... _) {
+            List<Conversation> conversations = databaseBackend.getConversations(Conversation.STATUS_AVAILABLE);
+            conversations.addAll(databaseBackend.getConversations(Conversation.STATUS_ARCHIVED));
+
+            setProgressBarMax(conversations.size());
+            int progress = 0;
+
+            for (Conversation conversation : conversations) {
+                writeToFile(conversation);
+                publishProgress(++progress);
+            }
+            return null;
+        }
+
+        private void writeToFile(Conversation conversation) {
+            Jid accountJid = resolveAccountUuid(conversation.getAccountUuid());
+            Jid contactJid = conversation.getJid();
+
+            File dir = new File(String.format(DIRECTORY_STRING_FORMAT,
+                    accountJid.toBareJid().toString(),
+                    contactJid.toBareJid().toString()));
+            dir.mkdirs();
+
+            ArrayList<Message> messages = databaseBackend.getMessages(conversation, Integer.MAX_VALUE);
+            BufferedWriter bw = null;
+            try {
+                for (Message message : messages) {
+                    String date = simpleDateFormat.format(new Date(message.getTimeSent()));
+                    if (bw == null) {
+                        bw = new BufferedWriter(new FileWriter(new File(dir, date + ".txt")));
+                    }
+                    String jid = null;
+                    switch (message.getStatus()) {
+                        case Message.STATUS_RECEIVED:
+                            jid = getMessageCounterpart(message);
+                            break;
+                        case Message.STATUS_SEND:
+                            jid = accountJid.toString();
+                            break;
+                    }
+                    if (jid != null) {
+                        bw.write(String.format(MESSAGE_STRING_FORMAT, date, jid,
+                                message.getBody().replace("\\\n", "\\ \n").replace("\n", "\\ \n")));
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally {
+                try {
+                    if (bw != null) {
+                        bw.close();
+                    }
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+            }
+        }
+
+        private Jid resolveAccountUuid(String accountUuid) {
+            for (Account account : accounts) {
+                if (account.getUuid().equals(accountUuid)) {
+                    return account.getJid();
+                }
+            }
+            return null;
+        }
+
+        private String getMessageCounterpart(Message message) {
+            String trueCounterpart = (String) message.getContentValues().get(Message.TRUE_COUNTERPART);
+            if (trueCounterpart != null) {
+                return trueCounterpart;
+            } else {
+                return message.getCounterpart().toString();
+            }
+        }
+
+        protected void onPreExecute() {
+            setProgressBarProgress(0);
+            progressBar.setVisibility(View.VISIBLE);
+        }
+
+        protected void onProgressUpdate(Integer... progress) {
+            setProgressBarProgress(progress[0]);
+        }
+
+        protected void onPostExecute(Void _) {
+            progressBar.setVisibility(View.INVISIBLE);
+        }
+    }
+}

--- a/src/main/res/layout/preference_export_logs.xml
+++ b/src/main/res/layout/preference_export_logs.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dip"
+            android:layout_marginLeft="15dip"
+            android:layout_marginEnd="6dip"
+            android:layout_marginRight="6dip"
+            android:layout_marginTop="6dip"
+            android:layout_marginBottom="6dip"
+            android:layout_weight="1">
+
+        <TextView android:id="@android:id/title"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:singleLine="true"
+                  android:textAppearance="?android:attr/textAppearanceListItem"
+                  android:ellipsize="marquee"
+                  android:fadingEdge="horizontal" />
+
+        <TextView android:id="@android:id/summary"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:layout_below="@android:id/title"
+                  android:layout_alignStart="@android:id/title"
+                  android:layout_alignLeft="@android:id/title"
+                  android:textAppearance="?android:attr/textAppearanceSmall"
+                  android:textColor="?android:attr/textColorSecondary"
+                  android:maxLines="4"/>
+    </RelativeLayout>
+
+    <ProgressBar
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/progress_bar" android:indeterminate="false"/>
+</LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -448,6 +448,8 @@
 	<string name="pref_enter_is_send_summary">Use enter key to send message</string>
 	<string name="pref_display_enter_key">Show enter key</string>
 	<string name="pref_display_enter_key_summary">Change the emoticons key to an enter key</string>
+	<string name="pref_backup_logs">Backup Logs</string>
+	<string name="pref_backup_logs_summary">Write logs to SD card</string>
 	<string name="audio">audio</string>
 	<string name="video">video</string>
 	<string name="image">image</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -172,6 +172,11 @@
                     android:key="keep_foreground_service"
                     android:title="@string/pref_keep_foreground_service"
                     android:summary="@string/pref_keep_foreground_service_summary" />
+                <eu.siacs.conversations.ui.ExportLogsPreference
+                    android:key="backup_logs"
+                    android:title="@string/pref_backup_logs"
+                    android:summary="@string/pref_backup_logs_summary"/>
+
             </PreferenceCategory>
         </PreferenceScreen>
 


### PR DESCRIPTION
Adds a preference "Backup to SD card" to Expert Options > Other.
It writes the logs to SD card in cleartext using a pidgin-like folder structure. The logs use the format "(time) jid: message \n". Newlines within chat messages are distinguished by "\" escaping them.

A similar feature was discussed in #1252, but I decided to use an easily human readable format to not make the feature only usable for people familiar with databases.