### PR TITLE
Allow user to specify http upload component manually

### DIFF
--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -1199,6 +1199,17 @@ public class XmppConnection implements Runnable {
 		}
 
 		public boolean httpUpload() {
+			String hoststr = mXmppConnectionService.getPreferences().getString("http_upload_service", "");
+			if(hoststr.length() > 0) {
+				try {
+					Jid.fromString(hoststr);
+					return true;
+				} catch (InvalidJidException ignored) {
+					// Ignore preference and use disco
+					Log.e(Config.LOGTAG, "Invalid http_upload_service JID "
+							+hoststr + ": " + ignored + ".");
+				}
+			}
 			return findDiscoItemsByFeature(Xmlns.HTTP_UPLOAD).size() > 0;
 		}
 	}

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -322,6 +322,8 @@
   <string name="conversations_foreground_service">Conversations</string>
   <string name="pref_keep_foreground_service">Den Dienst im Vordergrund ausführen.</string>
   <string name="pref_keep_foreground_service_summary">Verhindert, dass Android Conversations beendet und die Verbindung unterbricht</string>
+  <string name="pref_http_upload_service">Http Upload Dienst angeben</string>
+  <string name="pref_http_upload_service_summary">Eine eigene Http Upload Dienst Component JID angeben, falls der Konto-Server keinen eigenen Http Upload Dienst anbietet.</string>
   <string name="choose_file">Datei auswählen</string>
   <string name="receiving_x_file">Empfange  %1$s (%2$d%% abgeschlossen)</string>
   <string name="download_x_file">Lade %s herunter</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -363,6 +363,8 @@
 	<string name="conversations_foreground_service">Conversations</string>
 	<string name="pref_keep_foreground_service">Keep service in foreground</string>
 	<string name="pref_keep_foreground_service_summary">Prevents the operating system from killing your connection</string>
+	<string name="pref_http_upload_service">Specify http upload service</string>
+	<string name="pref_http_upload_service_summary">Specify a http upload service component JID if your server does not have its own upload service component.</string>
 	<string name="choose_file">Choose file</string>
 	<string name="receiving_x_file">Receiving %1$s (%2$d%% completed)</string>
 	<string name="download_x_file">Download %s</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -165,6 +165,11 @@
                     android:key="keep_foreground_service"
                     android:summary="@string/pref_keep_foreground_service_summary"
                     android:title="@string/pref_keep_foreground_service"/>
+                <EditTextPreference
+                    android:defaultValue=""
+                    android:key="http_upload_service"
+                    android:summary="@string/pref_http_upload_service_summary"
+                    android:title="@string/pref_http_upload_service"/>
             </PreferenceCategory>
         </PreferenceScreen>
 


### PR DESCRIPTION
Add a preference under expert settings to allow setting a http upload
component jid. This way users can use a different server to share files if
their own account server does not provide this service.