### PR TITLE
remove the READ_PHONE_STATE permission.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.NFC" />
 
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
remove the READ_PHONE_STATE permission from the build which is added when importing a library with a targetSdkVersion < 4