### PR TITLE
Add multi window support

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
                 <action android:name="android.intent.action.MAIN"/>
 
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER"/>
             </intent-filter>
         </activity>
         <activity
@@ -165,6 +166,11 @@
                 <action android:name="android.service.chooser.ChooserTargetService" />
             </intent-filter>
         </service>
+
+        <uses-library android:required="false" android:name="com.sec.android.app.multiwindow"> </uses-library>
+        <meta-data android:name="com.sec.android.support.multiwindow" android:value="true"/>
+        <meta-data android:name="com.sec.android.multiwindow.MINIMUM_SIZE_W" android:value="360dp"/>
+        <meta-data android:name="com.sec.android.multiwindow.MINIMUM_SIZE_H" android:value="181dp"/> <!-- 48dp + 2*12dp + 53dp + 56dp -->
     </application>
 
 </manifest>


### PR DESCRIPTION
Several smartphones and tablets by Samsung (and maybe others?) have support for showing multiple (two) windows/apps at once. I think chatting alongside another app would be great, thus I'd really like to have this feature.

Apparently, it is rather easy to implement too, according to [this thread](http://www.modaco.com/news/android/developers-add-support-for-samsung-multi-window-to-your-apps-r823) and [this question on SO](https://stackoverflow.com/questions/14111052/adding-multi-window-support-to-android-application) at least.
