### PR TITLE
PGP messages background decryption

### DIFF
--- a/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
+++ b/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
@@ -1,0 +1,162 @@
+package eu.siacs.conversations.crypto;
+
+import android.app.PendingIntent;
+
+import eu.siacs.conversations.entities.Message;
+import eu.siacs.conversations.services.XmppConnectionService;
+import eu.siacs.conversations.ui.UiCallback;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PgpDecryptionService {
+
+	private final XmppConnectionService xmppConnectionService;
+	private final ConcurrentHashMap<String, List<Message>> messages = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, Boolean> decryptingMessages = new ConcurrentHashMap<>();
+	private Boolean keychainLocked = false;
+	private final Object keychainLockedLock = new Object();
+
+	public PgpDecryptionService(XmppConnectionService xmppConnectionService) {
+		this.xmppConnectionService = xmppConnectionService;
+	}
+
+	public void add(Message message) {
+		if (isRunning()) {
+			decryptDirectly(message);
+		} else {
+			store(message);
+		}
+	}
+
+	public void addAll(List<Message> messagesList) {
+		if (!messagesList.isEmpty()) {
+			String conversationUuid = messagesList.get(0).getConversation().getUuid();
+			if (!messages.containsKey(conversationUuid)) {
+				List<Message> list = Collections.synchronizedList(new LinkedList<Message>());
+				messages.put(conversationUuid, list);
+			}
+			synchronized (messages.get(conversationUuid)) {
+				messages.get(conversationUuid).addAll(messagesList);
+			}
+			decryptAllMessages();
+		}
+	}
+
+	public void onKeychainUnlocked() {
+		synchronized (keychainLockedLock) {
+			keychainLocked = false;
+		}
+		decryptAllMessages();
+	}
+
+	public void onKeychainLocked() {
+		synchronized (keychainLockedLock) {
+			keychainLocked = true;
+		}
+		xmppConnectionService.updateConversationUi();
+	}
+
+	public void onOpenPgpServiceBound() {
+		decryptAllMessages();
+	}
+
+	public boolean isRunning() {
+		synchronized (keychainLockedLock) {
+			return !keychainLocked;
+		}
+	}
+
+	private void store(Message message) {
+		if (messages.containsKey(message.getConversation().getUuid())) {
+			messages.get(message.getConversation().getUuid()).add(message);
+		} else {
+			List<Message> messageList = Collections.synchronizedList(new LinkedList<Message>());
+			messageList.add(message);
+			messages.put(message.getConversation().getUuid(), messageList);
+		}
+	}
+
+	private void decryptAllMessages() {
+		for (String uuid : messages.keySet()) {
+			decryptMessages(uuid);
+		}
+	}
+
+	private void decryptMessages(final String uuid) {
+		synchronized (decryptingMessages) {
+			Boolean decrypting = decryptingMessages.get(uuid);
+			if ((decrypting != null && !decrypting) || decrypting == null) {
+				decryptingMessages.put(uuid, true);
+				decryptMessage(uuid);
+			}
+		}
+	}
+
+	private void decryptMessage(final String uuid) {
+		Message message = null;
+		synchronized (messages.get(uuid)) {
+			while (!messages.get(uuid).isEmpty()) {
+				if (messages.get(uuid).get(0).getEncryption() == Message.ENCRYPTION_PGP) {
+					if (isRunning()) {
+						message = messages.get(uuid).remove(0);
+					}
+					break;
+				} else {
+					messages.get(uuid).remove(0);
+				}
+			}
+			if (message != null && xmppConnectionService.getPgpEngine() != null) {
+				xmppConnectionService.getPgpEngine().decrypt(message, new UiCallback<Message>() {
+
+					@Override
+					public void userInputRequried(PendingIntent pi, Message message) {
+						messages.get(uuid).add(0, message);
+						decryptingMessages.put(uuid, false);
+					}
+
+					@Override
+					public void success(Message message) {
+						xmppConnectionService.updateConversationUi();
+						decryptMessage(uuid);
+					}
+
+					@Override
+					public void error(int error, Message message) {
+						message.setEncryption(Message.ENCRYPTION_DECRYPTION_FAILED);
+						xmppConnectionService.updateConversationUi();
+						decryptMessage(uuid);
+					}
+				});
+			} else {
+				decryptingMessages.put(uuid, false);
+			}
+		}
+	}
+
+	private void decryptDirectly(final Message message) {
+		if (message.getEncryption() == Message.ENCRYPTION_PGP && xmppConnectionService.getPgpEngine() != null) {
+			xmppConnectionService.getPgpEngine().decrypt(message, new UiCallback<Message>() {
+
+				@Override
+				public void userInputRequried(PendingIntent pi, Message message) {
+					store(message);
+				}
+
+				@Override
+				public void success(Message message) {
+					xmppConnectionService.updateConversationUi();
+					xmppConnectionService.getNotificationService().updateNotification(false);
+				}
+
+				@Override
+				public void error(int error, Message message) {
+					message.setEncryption(Message.ENCRYPTION_DECRYPTION_FAILED);
+					xmppConnectionService.updateConversationUi();
+				}
+			});
+		}
+	}
+}

--- a/src/main/java/eu/siacs/conversations/entities/Account.java
+++ b/src/main/java/eu/siacs/conversations/entities/Account.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.os.SystemClock;
 
+import eu.siacs.conversations.crypto.PgpDecryptionService;
 import net.java.otr4j.crypto.OtrCryptoEngineImpl;
 import net.java.otr4j.crypto.OtrCryptoException;
 
@@ -127,6 +128,7 @@ public class Account extends AbstractEntity {
 	protected boolean online = false;
 	private OtrService mOtrService = null;
 	private AxolotlService axolotlService = null;
+	private PgpDecryptionService pgpDecryptionService = null;
 	private XmppConnection xmppConnection = null;
 	private long mEndGracePeriod = 0L;
 	private String otrFingerprint;
@@ -300,10 +302,15 @@ public class Account extends AbstractEntity {
 		if (xmppConnection != null) {
 			xmppConnection.addOnAdvancedStreamFeaturesAvailableListener(axolotlService);
 		}
+		this.pgpDecryptionService = new PgpDecryptionService(context);
 	}
 
 	public OtrService getOtrService() {
 		return this.mOtrService;
+	}
+
+	public PgpDecryptionService getPgpDecryptionService() {
+		return pgpDecryptionService;
 	}
 
 	public XmppConnection getXmppConnection() {

--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -777,6 +777,7 @@ public class Conversation extends AbstractEntity implements Blockable {
 		synchronized (this.messages) {
 			this.messages.addAll(index, messages);
 		}
+		account.getPgpDecryptionService().addAll(messages);
 	}
 
 	public void sort() {

--- a/src/main/java/eu/siacs/conversations/parser/MessageParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/MessageParser.java
@@ -3,6 +3,7 @@ package eu.siacs.conversations.parser;
 import android.util.Log;
 import android.util.Pair;
 
+import eu.siacs.conversations.crypto.PgpDecryptionService;
 import net.java.otr4j.session.Session;
 import net.java.otr4j.session.SessionStatus;
 
@@ -112,6 +113,13 @@ public class MessageParser extends AbstractParser implements
 		}
 
 		return finishedMessage;
+	}
+
+	private Message parsePGPChat(final Conversation conversation, String pgpEncrypted, int status) {
+		final Message message = new Message(conversation, pgpEncrypted, Message.ENCRYPTION_PGP, status);
+		PgpDecryptionService pgpDecryptionService = conversation.getAccount().getPgpDecryptionService();
+		pgpDecryptionService.add(message);
+		return message;
 	}
 
 	private class Invite {
@@ -337,7 +345,7 @@ public class MessageParser extends AbstractParser implements
 					message = new Message(conversation, body, Message.ENCRYPTION_NONE, status);
 				}
 			} else if (pgpEncrypted != null) {
-				message = new Message(conversation, pgpEncrypted, Message.ENCRYPTION_PGP, status);
+				message = parsePGPChat(conversation, pgpEncrypted, status);
 			} else if (axolotlEncrypted != null) {
 				message = parseAxolotlChat(axolotlEncrypted, from, remoteMsgId, conversation, status);
 				if (message == null) {

--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -177,7 +177,7 @@ public class NotificationService {
 		mBuilder.setColor(mXmppConnectionService.getResources().getColor(R.color.primary));
 	}
 
-	private void updateNotification(final boolean notify) {
+	public void updateNotification(final boolean notify) {
 		final NotificationManager notificationManager = (NotificationManager) mXmppConnectionService
 			.getSystemService(Context.NOTIFICATION_SERVICE);
 		final SharedPreferences preferences = mXmppConnectionService.getPreferences();

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -37,6 +37,7 @@ import net.java.otr4j.session.SessionID;
 import net.java.otr4j.session.SessionImpl;
 import net.java.otr4j.session.SessionStatus;
 
+import org.openintents.openpgp.IOpenPgpService;
 import org.openintents.openpgp.util.OpenPgpApi;
 import org.openintents.openpgp.util.OpenPgpServiceConnection;
 
@@ -659,7 +660,19 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 		getContentResolver().registerContentObserver(ContactsContract.Contacts.CONTENT_URI, true, contactObserver);
 		this.fileObserver.startWatching();
 
-		this.pgpServiceConnection = new OpenPgpServiceConnection(getApplicationContext(), "org.sufficientlysecure.keychain");
+		this.pgpServiceConnection = new OpenPgpServiceConnection(getApplicationContext(), "org.sufficientlysecure.keychain", new OpenPgpServiceConnection.OnBound() {
+			@Override
+			public void onBound(IOpenPgpService service) {
+				for (Account account : accounts) {
+					if (account.getPgpDecryptionService() != null) {
+						account.getPgpDecryptionService().onOpenPgpServiceBound();
+					}
+				}
+			}
+
+			@Override
+			public void onError(Exception e) { }
+		});
 		this.pgpServiceConnection.bindToService();
 
 		this.pm = (PowerManager) getSystemService(Context.POWER_SERVICE);

--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -1194,8 +1194,7 @@ public class ConversationActivity extends XmppActivity
 		super.onActivityResult(requestCode, resultCode, data);
 		if (resultCode == RESULT_OK) {
 			if (requestCode == REQUEST_DECRYPT_PGP) {
-				mConversationFragment.hideSnackbar();
-				mConversationFragment.updateMessages();
+				mConversationFragment.onActivityResult(requestCode, resultCode, data);
 			} else if (requestCode == ATTACHMENT_CHOICE_CHOOSE_IMAGE) {
 				mPendingImageUris.clear();
 				mPendingImageUris.addAll(extractUriFromIntent(data));
@@ -1240,6 +1239,9 @@ public class ConversationActivity extends XmppActivity
 		} else {
 			mPendingImageUris.clear();
 			mPendingFileUris.clear();
+			if (requestCode == ConversationActivity.REQUEST_DECRYPT_PGP) {
+				mConversationFragment.onActivityResult(requestCode, resultCode, data);
+			}
 		}
 	}
 

--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -550,7 +550,11 @@ public class MessageAdapter extends ArrayAdapter<Message> {
 			}
 		} else if (message.getEncryption() == Message.ENCRYPTION_PGP) {
 			if (activity.hasPgp()) {
-				displayInfoMessage(viewHolder,activity.getString(R.string.encrypted_message),darkBackground);
+				if (account.getPgpDecryptionService().isRunning()) {
+					displayInfoMessage(viewHolder, activity.getString(R.string.message_decrypting), darkBackground);
+				} else {
+					displayInfoMessage(viewHolder, activity.getString(R.string.pgp_message), darkBackground);
+				}
 			} else {
 				displayInfoMessage(viewHolder,activity.getString(R.string.install_openkeychain),darkBackground);
 				if (viewHolder != null) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -30,7 +30,8 @@
 	<string name="minutes_ago">%d mins ago</string>
 	<string name="unread_conversations">unread Conversations</string>
 	<string name="sending">sending…</string>
-	<string name="encrypted_message">Decrypting message. Please wait…</string>
+	<string name="message_decrypting">Decrypting message. Please wait…</string>
+	<string name="pgp_message">OpenPGP encrypted message</string>
 	<string name="nick_in_use">Nickname is already in use</string>
 	<string name="admin">Admin</string>
 	<string name="owner">Owner</string>


### PR DESCRIPTION
PGP messages are only decrypted while the correspondent conversation is in foreground. Because of that
- Notifications are not meaningful
- Depending on the device, it takes quite a while to decrypt everything, especially if PGP messages where sent from another device with carbon-copy enabled.
As messages are decrypted in order, it is also impossible to continue communicating while waiting for the decryption to finish.

This patch adds a decryption service to the backend, which keeps track of the (un)locked state of the Keychain and manages the decryption. Old messages are decrypted in-order; new ones as they come in.