### PR TITLE
Handle some orientation changes manually

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
         <activity
             android:name=".ui.ConversationActivity"
             android:label="@string/app_name"
+            android:configChanges="orientation|screenSize"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden">
             <intent-filter>
@@ -95,14 +96,17 @@
             android:launchMode="singleTask"/>
         <activity
             android:name=".ui.EditAccountActivity"
+            android:configChanges="orientation|screenSize"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden|adjustResize"/>
         <activity
             android:name=".ui.ConferenceDetailsActivity"
+            android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_conference_details"
             android:windowSoftInputMode="stateHidden"/>
         <activity
             android:name=".ui.ContactDetailsActivity"
+            android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_contact_details"
             android:windowSoftInputMode="stateHidden"/>
         <activity

--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -6,6 +6,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.IntentSender.SendIntentException;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Bundle;
@@ -41,6 +42,7 @@ import eu.siacs.conversations.entities.MucOptions.User;
 import eu.siacs.conversations.services.XmppConnectionService;
 import eu.siacs.conversations.services.XmppConnectionService.OnConversationUpdate;
 import eu.siacs.conversations.services.XmppConnectionService.OnMucRosterUpdate;
+import eu.siacs.conversations.utils.UIHelper;
 import eu.siacs.conversations.xmpp.jid.Jid;
 
 public class ConferenceDetailsActivity extends XmppActivity implements OnConversationUpdate, OnMucRosterUpdate, XmppConnectionService.OnAffiliationChanged, XmppConnectionService.OnRoleChanged, XmppConnectionService.OnConferenceOptionsPushed {
@@ -53,6 +55,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 			inviteToConversation(mConversation);
 		}
 	};
+	private LinearLayout mMainLayout;
 	private TextView mYourNick;
 	private ImageView mYourPhoto;
 	private ImageButton mEditNickButton;
@@ -187,6 +190,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_muc_details);
+		mMainLayout = (LinearLayout) findViewById(R.id.muc_main_layout);
 		mYourNick = (TextView) findViewById(R.id.muc_your_nick);
 		mYourPhoto = (ImageView) findViewById(R.id.your_photo);
 		mEditNickButton = (ImageButton) findViewById(R.id.edit_nick_button);
@@ -448,6 +452,12 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 				updateView();
 			}
 		}
+	}
+
+	@Override
+	public void onConfigurationChanged (Configuration newConfig) {
+		super.onConfigurationChanged(newConfig);
+		UIHelper.resetChildMargins(mMainLayout);
 	}
 
 	private void updateView() {

--- a/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
@@ -7,6 +7,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentSender.SendIntentException;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -99,6 +100,7 @@ public class ContactDetailsActivity extends XmppActivity implements OnAccountUpd
 			}
 		}
 	};
+	private LinearLayout mainLayout;
 	private Jid accountJid;
 	private Jid contactJid;
 	private TextView contactJidTv;
@@ -197,6 +199,7 @@ public class ContactDetailsActivity extends XmppActivity implements OnAccountUpd
 		this.messageFingerprint = getIntent().getStringExtra("fingerprint");
 		setContentView(R.layout.activity_contact_details);
 
+		mainLayout = (LinearLayout) findViewById(R.id.details_main_layout);
 		contactJidTv = (TextView) findViewById(R.id.details_contactjid);
 		accountJidTv = (TextView) findViewById(R.id.details_account);
 		lastseen = (TextView) findViewById(R.id.details_lastseen);
@@ -295,6 +298,12 @@ public class ContactDetailsActivity extends XmppActivity implements OnAccountUpd
 			delete.setVisible(false);
 		}
 		return true;
+	}
+
+	@Override
+	public void onConfigurationChanged (Configuration newConfig) {
+		super.onConfigurationChanged(newConfig);
+		UIHelper.resetChildMargins(mainLayout);
 	}
 
 	private void populateView() {

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -5,6 +5,7 @@ import android.app.AlertDialog.Builder;
 import android.app.PendingIntent;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.security.KeyChain;
@@ -51,6 +52,7 @@ import eu.siacs.conversations.xmpp.pep.Avatar;
 public class EditAccountActivity extends XmppActivity implements OnAccountUpdate,
 		OnKeyStatusUpdated, OnCaptchaRequested, KeyChainAliasCallback, XmppConnectionService.OnShowErrorToast {
 
+	private LinearLayout mMainLayout;
 	private AutoCompleteTextView mAccountJid;
 	private EditText mPassword;
 	private EditText mPasswordConfirm;
@@ -333,6 +335,7 @@ public class EditAccountActivity extends XmppActivity implements OnAccountUpdate
 	protected void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_edit_account);
+		this.mMainLayout = (LinearLayout) findViewById(R.id.account_main_layout);
 		this.mAccountJid = (AutoCompleteTextView) findViewById(R.id.account_jid);
 		this.mAccountJid.addTextChangedListener(this.mTextWatcher);
 		this.mAccountJidLabel = (TextView) findViewById(R.id.account_jid_label);
@@ -476,6 +479,12 @@ public class EditAccountActivity extends XmppActivity implements OnAccountUpdate
 			this.mAccountJid.setAdapter(mKnownHostsAdapter);
 		}
 		updateSaveButton();
+	}
+
+	@Override
+	public void onConfigurationChanged (Configuration newConfig) {
+		super.onConfigurationChanged(newConfig);
+		UIHelper.resetChildMargins(mMainLayout);
 	}
 
 	@Override

--- a/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
@@ -441,7 +441,7 @@ public abstract class XmppActivity extends Activity {
 	}
 
 	public void switchToAccount(Account account) {
-		switchToAccount(account,false);
+		switchToAccount(account, false);
 	}
 
 	public void switchToAccount(Account account, boolean init) {

--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -3,7 +3,11 @@ package eu.siacs.conversations.utils;
 import android.content.Context;
 import android.text.format.DateFormat;
 import android.text.format.DateUtils;
+import android.util.DisplayMetrics;
 import android.util.Pair;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -260,5 +264,22 @@ public class UIHelper {
 		String body = message.getBody() == null ? null : message.getBody().trim().toLowerCase(Locale.getDefault());
 		body = body.replace("?","").replace("¿","");
 		return LOCATION_QUESTIONS.contains(body);
+	}
+
+	public static void resetChildMargins(LinearLayout view) {
+		int childCount = view.getChildCount();
+		for (int i = 0; i < childCount; i++) {
+			UIHelper.resetMargins(view.getChildAt(i));
+		}
+	}
+
+	private static void resetMargins(View view) {
+		LinearLayout.MarginLayoutParams marginLayoutParams = new LinearLayout.MarginLayoutParams(view.getLayoutParams());
+		marginLayoutParams.setMargins(view.getResources().getDimensionPixelSize(R.dimen.activity_horizontal_margin),
+				view.getResources().getDimensionPixelSize(R.dimen.activity_vertical_margin),
+				view.getResources().getDimensionPixelSize(R.dimen.activity_horizontal_margin),
+				view.getResources().getDimensionPixelSize(R.dimen.activity_vertical_margin));
+		LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(marginLayoutParams);
+		view.setLayoutParams(layoutParams);
 	}
 }

--- a/src/main/res/layout/activity_contact_details.xml
+++ b/src/main/res/layout/activity_contact_details.xml
@@ -5,6 +5,7 @@
     android:background="@color/grey200" >
 
     <LinearLayout
+        android:id="@+id/details_main_layout"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical" >

--- a/src/main/res/layout/activity_edit_account.xml
+++ b/src/main/res/layout/activity_edit_account.xml
@@ -13,6 +13,7 @@
         android:layout_alignParentTop="true" >
 
         <LinearLayout
+            android:id="@+id/account_main_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical" >

--- a/src/main/res/layout/activity_muc_details.xml
+++ b/src/main/res/layout/activity_muc_details.xml
@@ -6,6 +6,7 @@
 			android:background="@color/grey200">
 
 	<LinearLayout
+		android:id="@+id/muc_main_layout"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:orientation="vertical">


### PR DESCRIPTION
Currently most activities get destroyed/recreated when rotating the device. This commit prevents this from happening where it is not necessary.

The most obvious improvements are:

 * The options menu in the EditAccountActivity does not disappear when rotating the device.
 * CSI inactive/active states are no longer sent on every rotate.

While I tested this and it works fine for me it would probably be good for others to test this first before merging.