### PR TITLE
Show the fingerprints consistently

### DIFF
--- a/src/main/java/eu/siacs/conversations/utils/CryptoHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/CryptoHelper.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.xmpp.jid.InvalidJidException;
@@ -107,6 +108,7 @@ public final class CryptoHelper {
 	}
 
 	public static String prettifyFingerprint(String fingerprint) {
+		fingerprint = fingerprint.toLowerCase(Locale.ENGLISH);
 		if (fingerprint==null) {
 			return "";
 		} else if (fingerprint.length() < 40) {

--- a/src/main/java/eu/siacs/conversations/utils/CryptoHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/CryptoHelper.java
@@ -108,10 +108,13 @@ public final class CryptoHelper {
 	}
 
 	public static String prettifyFingerprint(String fingerprint) {
-		fingerprint = fingerprint.toLowerCase(Locale.ENGLISH);
 		if (fingerprint==null) {
 			return "";
-		} else if (fingerprint.length() < 40) {
+		}
+
+		fingerprint = fingerprint.toLowerCase(Locale.ENGLISH);
+
+		if (fingerprint.length() < 40) {
 			return fingerprint;
 		}
 		StringBuilder builder = new StringBuilder(fingerprint.replaceAll("\\s",""));


### PR DESCRIPTION
Currently, OTR fingerprints are displayed in uppercase whereas OMEMO fingerprints are displayed in lowercase. This commit fixes this inconsistency by displaying all fingerprints in lowercase.