### PR TITLE
Don't synchronize on non-final field

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Presences.java
+++ b/src/main/java/eu/siacs/conversations/entities/Presences.java
@@ -15,7 +15,7 @@ public class Presences {
 	public static final int DND = 3;
 	public static final int OFFLINE = 4;
 
-	private Hashtable<String, Integer> presences = new Hashtable<String, Integer>();
+	private final Hashtable<String, Integer> presences = new Hashtable<>();
 
 	public Hashtable<String, Integer> getPresences() {
 		return this.presences;


### PR DESCRIPTION
Minor tweak to make the presences hash table final.

This is only partially my usual weirdness about things being final; we synchronize on the presences table a few times and it's unsafe to EVER sync on something that's not final (sync doesn't matter if the collection you're syncing on changes to a completely different collection in the middle of the operation).