### PR TITLE
Show status message when contact requests presence

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Message.java
+++ b/src/main/java/eu/siacs/conversations/entities/Message.java
@@ -171,7 +171,7 @@ public class Message extends AbstractEntity {
 	}
 
 	public static Message createStatusMessage(Conversation conversation, String body) {
-		Message message = new Message();
+		final Message message = new Message();
 		message.setType(Message.TYPE_STATUS);
 		message.setConversation(conversation);
 		message.setBody(body);

--- a/src/main/java/eu/siacs/conversations/parser/PresenceParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/PresenceParser.java
@@ -6,6 +6,7 @@ import eu.siacs.conversations.crypto.PgpEngine;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Contact;
 import eu.siacs.conversations.entities.Conversation;
+import eu.siacs.conversations.entities.Message;
 import eu.siacs.conversations.entities.MucOptions;
 import eu.siacs.conversations.entities.Presences;
 import eu.siacs.conversations.generator.PresenceGenerator;
@@ -44,8 +45,8 @@ public class PresenceParser extends AbstractParser implements
 		}
 	}
 
-	public void parseContactPresence(PresencePacket packet, Account account) {
-		PresenceGenerator mPresenceGenerator = mXmppConnectionService.getPresenceGenerator();
+	public void parseContactPresence(final PresencePacket packet, final Account account) {
+		final PresenceGenerator mPresenceGenerator = mXmppConnectionService.getPresenceGenerator();
 		final Jid from = packet.getFrom();
 		if (from == null) {
 			return;
@@ -93,6 +94,17 @@ public class PresenceParser extends AbstractParser implements
 						mPresenceGenerator.sendPresenceUpdatesTo(contact));
 			} else {
 				contact.setOption(Contact.Options.PENDING_SUBSCRIPTION_REQUEST);
+				final String statusMessage = packet.findChildContent("status");
+				if (statusMessage != null && !statusMessage.isEmpty()) {
+					final Conversation conversation = mXmppConnectionService.findOrCreateConversation(
+							account, contact.getJid().toBareJid(), false);
+					conversation.add(new Message(
+							conversation,
+							statusMessage,
+							Message.ENCRYPTION_NONE,
+							Message.STATUS_RECEIVED
+					));
+				}
 			}
 		}
 		mXmppConnectionService.updateRosterUi();

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -1322,6 +1322,13 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 				leaveMuc(conversation);
 			} else {
 				conversation.endOtrIfNeeded();
+				if (conversation.getContact().getOption(Contact.Options.PENDING_SUBSCRIPTION_REQUEST)) {
+					Log.d(Config.LOGTAG, "Canceling presence request from " + conversation.getJid().toString());
+					sendPresencePacket(
+							conversation.getAccount(),
+							mPresenceGenerator.stopPresenceUpdatesTo(conversation.getContact())
+					);
+				}
 			}
 			this.databaseBackend.updateConversation(conversation);
 			this.conversations.remove(conversation);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -218,7 +218,7 @@
 	<string name="this_device_omemo_fingerprint">Own OMEMO fingerprint</string>
 	<string name="other_devices">Other devices</string>
 	<string name="trust_omemo_fingerprints">Trust OMEMO Fingerprints</string>
-	<string name="fetching_keys">Fetching keys...</string>
+	<string name="fetching_keys">Fetching keys…</string>
 	<string name="done">Done</string>
 	<string name="verify">Verify</string>
 	<string name="decrypt">Decrypt</string>
@@ -478,7 +478,7 @@
 	<string name="offering_x_file">Offering %s</string>
 	<string name="hide_offline">Hide offline</string>
 	<string name="disable_account">Disable Account</string>
-	<string name="contact_is_typing">%s is typing...</string>
+	<string name="contact_is_typing">%s is typing…</string>
 	<string name="contact_has_stopped_typing">%s has stopped typing</string>
 	<string name="pref_chat_states">Typing notifications</string>
 	<string name="pref_chat_states_summary">Let your contact know when you are writing a new message</string>


### PR DESCRIPTION
Currently when a contact requests your presence (but does not send you a message), you are not informed that they've added you. This makes it quite easy to miss presence requests. This PR fixes that by opening a conversation with the contact, and displaying their status (if available) as ~~if it were a chat state message~~ a normal message.