### PR TITLE
Let users crop their avatar images using the android-crop library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ allprojects {
 	repositories {
 		jcenter()
 		mavenCentral()
+		maven {
+			url 'http://lorenzo.villani.me/android-cropimage/'
+		}
 	}
 }
 
@@ -27,6 +30,7 @@ repositories {
 dependencies {
 	compile project(':libs:MemorizingTrustManager')
 	compile 'org.sufficientlysecure:openpgp-api:9.0'
+	compile 'com.soundcloud.android:android-crop:1.0.1@aar'
 	compile 'com.android.support:support-v13:23.0.1'
 	compile 'org.bouncycastle:bcprov-jdk15on:1.52'
 	compile 'org.bouncycastle:bcmail-jdk15on:1.52'

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -153,7 +153,7 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="eu.siacs.conversations.ui.SettingsActivity"/>
         </activity>
-
+        <activity android:name="com.soundcloud.android.crop.CropImageActivity" />
         <service android:name=".services.ExportLogsService"/>
     </application>
 

--- a/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
@@ -486,14 +486,14 @@ public class FileBackend {
 		return calcSampleSize(options, size);
 	}
 
-	private int calcSampleSize(File image, int size) {
+	public static int calcSampleSize(File image, int size) {
 		BitmapFactory.Options options = new BitmapFactory.Options();
 		options.inJustDecodeBounds = true;
 		BitmapFactory.decodeFile(image.getAbsolutePath(), options);
 		return calcSampleSize(options, size);
 	}
 
-	public static int calcSampleSize(BitmapFactory.Options options, int size) {
+	private static int calcSampleSize(BitmapFactory.Options options, int size) {
 		int height = options.outHeight;
 		int width = options.outWidth;
 		int inSampleSize = 1;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -314,6 +314,7 @@
 			\n\nhttps://github.com/kyleduo/SwitchButton\n(Apache License, Version 2.0)
 			\n\nhttps://github.com/WhisperSystems/libaxolotl-java\n(GPLv3)
 			\n\nhttps://github.com/vinc3m1/RoundedImageView\n(Apache License, Version 2.0)
+			\n\nhttps://github.com/jdamcd/android-crop\n(Apache License, Version 2.0)
 	</string>
 	<string name="title_pref_quiet_hours">Quiet Hours</string>
 	<string name="title_pref_quiet_hours_start_time">Start time</string>


### PR DESCRIPTION
implements #1534 using the android-crop library
https://github.com/jdamcd/android-crop

This lets users crop their images instead of automatically cropping them.


