### PR TITLE
remove 'code assist' mistake

### DIFF
--- a/src/main/java/eu/siacs/conversations/xmpp/chatstate/ChatState.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/chatstate/ChatState.java
@@ -4,7 +4,7 @@ import eu.siacs.conversations.xml.Element;
 
 public enum ChatState {
 
-	ACTIVE, INACTIVE, GONE, COMPOSING, PAUSED, mIncomingChatState;
+	ACTIVE, INACTIVE, GONE, COMPOSING, PAUSED;
 
 	public static ChatState parse(Element element) {
 		final String NAMESPACE = "http://jabber.org/protocol/chatstates";


### PR DESCRIPTION
This enum value was definitely added as a code assist mistake and it was overlooked. I'm pretty sure that it shouldn't be here.