### PR TITLE
Regenerate PGP signatures once

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Account.java
+++ b/src/main/java/eu/siacs/conversations/entities/Account.java
@@ -413,13 +413,13 @@ public class Account extends AbstractEntity {
 	}
 
 	public String getPgpSignature() {
-		if (keys.has(KEY_PGP_SIGNATURE)) {
-			try {
+		try {
+			if (keys.has(KEY_PGP_SIGNATURE) && !"null".equals(keys.getString(KEY_PGP_SIGNATURE))) {
 				return keys.getString(KEY_PGP_SIGNATURE);
-			} catch (final JSONException e) {
+			} else {
 				return null;
 			}
-		} else {
+		} catch (final JSONException e) {
 			return null;
 		}
 	}
@@ -427,6 +427,15 @@ public class Account extends AbstractEntity {
 	public boolean setPgpSignature(String signature) {
 		try {
 			keys.put(KEY_PGP_SIGNATURE, signature);
+		} catch (JSONException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public boolean unsetPgpSignature() {
+		try {
+			keys.put(KEY_PGP_SIGNATURE, JSONObject.NULL);
 		} catch (JSONException e) {
 			return false;
 		}

--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -43,7 +43,7 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 	private static DatabaseBackend instance = null;
 
 	private static final String DATABASE_NAME = "history";
-	private static final int DATABASE_VERSION = 20;
+	private static final int DATABASE_VERSION = 21;
 
 	private static String CREATE_CONTATCS_STATEMENT = "create table "
 			+ Contact.TABLENAME + "(" + Contact.ACCOUNT + " TEXT, "
@@ -334,6 +334,15 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 		}
 		if (oldVersion < 18 && newVersion >= 18) {
 			db.execSQL("ALTER TABLE " + Message.TABLENAME + " ADD COLUMN " + Message.READ + " NUMBER DEFAULT 1");
+		}
+
+		if (oldVersion < 21 && newVersion >= 21) {
+			List<Account> accounts = getAccounts(db);
+			for (Account account : accounts) {
+				account.unsetPgpSignature();
+				db.update(Account.TABLENAME, account.getContentValues(), Account.UUID
+						+ "=?", new String[]{account.getUuid()});
+			}
 		}
 	}
 

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -1062,81 +1062,85 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 		final ConversationActivity activity = (ConversationActivity) getActivity();
 		final XmppConnectionService xmppService = activity.xmppConnectionService;
 		final Contact contact = message.getConversation().getContact();
-		if (activity.hasPgp()) {
-			if (conversation.getMode() == Conversation.MODE_SINGLE) {
-				if (contact.getPgpKeyId() != 0) {
-					xmppService.getPgpEngine().hasKey(contact,
-							new UiCallback<Contact>() {
+		if (!activity.hasPgp()) {
+			activity.showInstallPgpDialog();
+			return;
+		}
+		if (conversation.getAccount().getPgpSignature() == null) {
+			activity.announcePgp(conversation.getAccount(), conversation);
+			return;
+		}
+		if (conversation.getMode() == Conversation.MODE_SINGLE) {
+			if (contact.getPgpKeyId() != 0) {
+				xmppService.getPgpEngine().hasKey(contact,
+						new UiCallback<Contact>() {
 
-								@Override
-								public void userInputRequried(PendingIntent pi,
-															  Contact contact) {
-									activity.runIntent(
-											pi,
-											ConversationActivity.REQUEST_ENCRYPT_MESSAGE);
-								}
+							@Override
+							public void userInputRequried(PendingIntent pi,
+														  Contact contact) {
+								activity.runIntent(
+										pi,
+										ConversationActivity.REQUEST_ENCRYPT_MESSAGE);
+							}
 
-								@Override
-								public void success(Contact contact) {
-									messageSent();
-									activity.encryptTextMessage(message);
-								}
+							@Override
+							public void success(Contact contact) {
+								messageSent();
+								activity.encryptTextMessage(message);
+							}
 
-								@Override
-								public void error(int error, Contact contact) {
+							@Override
+							public void error(int error, Contact contact) {
+								System.out.println();
+							}
+						});
 
-								}
-							});
-
-				} else {
-					showNoPGPKeyDialog(false,
-							new DialogInterface.OnClickListener() {
-
-								@Override
-								public void onClick(DialogInterface dialog,
-													int which) {
-									conversation
-											.setNextEncryption(Message.ENCRYPTION_NONE);
-									xmppService.databaseBackend
-											.updateConversation(conversation);
-									message.setEncryption(Message.ENCRYPTION_NONE);
-									xmppService.sendMessage(message);
-									messageSent();
-								}
-							});
-				}
 			} else {
-				if (conversation.getMucOptions().pgpKeysInUse()) {
-					if (!conversation.getMucOptions().everybodyHasKeys()) {
-						Toast warning = Toast
-								.makeText(getActivity(),
-										R.string.missing_public_keys,
-										Toast.LENGTH_LONG);
-						warning.setGravity(Gravity.CENTER_VERTICAL, 0, 0);
-						warning.show();
-					}
-					activity.encryptTextMessage(message);
-					messageSent();
-				} else {
-					showNoPGPKeyDialog(true,
-							new DialogInterface.OnClickListener() {
+				showNoPGPKeyDialog(false,
+						new DialogInterface.OnClickListener() {
 
-								@Override
-								public void onClick(DialogInterface dialog,
-													int which) {
-									conversation
-											.setNextEncryption(Message.ENCRYPTION_NONE);
-									message.setEncryption(Message.ENCRYPTION_NONE);
-									xmppService.databaseBackend
-											.updateConversation(conversation);
-									xmppService.sendMessage(message);
-									messageSent();
-								}
-							});
-				}
+							@Override
+							public void onClick(DialogInterface dialog,
+												int which) {
+								conversation
+										.setNextEncryption(Message.ENCRYPTION_NONE);
+								xmppService.databaseBackend
+										.updateConversation(conversation);
+								message.setEncryption(Message.ENCRYPTION_NONE);
+								xmppService.sendMessage(message);
+								messageSent();
+							}
+						});
 			}
 		} else {
-			activity.showInstallPgpDialog();
+			if (conversation.getMucOptions().pgpKeysInUse()) {
+				if (!conversation.getMucOptions().everybodyHasKeys()) {
+					Toast warning = Toast
+							.makeText(getActivity(),
+									R.string.missing_public_keys,
+									Toast.LENGTH_LONG);
+					warning.setGravity(Gravity.CENTER_VERTICAL, 0, 0);
+					warning.show();
+				}
+				activity.encryptTextMessage(message);
+				messageSent();
+			} else {
+				showNoPGPKeyDialog(true,
+						new DialogInterface.OnClickListener() {
+
+							@Override
+							public void onClick(DialogInterface dialog,
+												int which) {
+								conversation
+										.setNextEncryption(Message.ENCRYPTION_NONE);
+								message.setEncryption(Message.ENCRYPTION_NONE);
+								xmppService.databaseBackend
+										.updateConversation(conversation);
+								xmppService.sendMessage(message);
+								messageSent();
+							}
+						});
+			}
 		}
 	}
 


### PR DESCRIPTION
As the status was removed for accounts with PGP enabled (c7a519498a88235488bb3a35d6220c64f7d88d0a), the signature has to be updated once.