### PR TITLE
Only store OMEMO if saveEncryptedMessages

### DIFF
--- a/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
+++ b/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
@@ -65,7 +65,11 @@ public class MessageGenerator extends AbstractGenerator {
 			return null;
 		}
 		packet.setAxolotlMessage(axolotlMessage.toElement());
-		packet.addChild("store", "urn:xmpp:hints");
+		if (this.mXmppConnectionService.saveEncryptedMessages()) {
+			packet.addChild("store", "urn:xmpp:hints");
+		} else {
+			packet.addChild("no-permanent-store", "urn:xmpp:hints");
+		}
 		return packet;
 	}
 


### PR DESCRIPTION
If dont_save_encrypted is checked, send the "no-permanent-store"
hint to disable MAM when sending OMEMO messages. Unfortunately,
this will prevent messages from being copied to offline devices.