### PR TITLE
(WIP, do not merge) New PGP Implementation (XEP-0374)

### DIFF
--- a/src/main/java/eu/siacs/conversations/crypto/BasePgpEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/BasePgpEngine.java
@@ -10,8 +10,6 @@ import eu.siacs.conversations.ui.UiCallback;
 public interface BasePgpEngine {
     void decrypt(final Message message, final UiCallback<Message> callback);
 
-    void encrypt(final Message message, final UiCallback<Message> callback);
-
     long fetchKeyId(Account account, String status, String signature);
 
     void chooseKey(final Account account, final UiCallback<Account> callback);

--- a/src/main/java/eu/siacs/conversations/crypto/BasePgpEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/BasePgpEngine.java
@@ -1,0 +1,23 @@
+package eu.siacs.conversations.crypto;
+
+import android.app.PendingIntent;
+
+import eu.siacs.conversations.entities.Account;
+import eu.siacs.conversations.entities.Contact;
+import eu.siacs.conversations.entities.Message;
+import eu.siacs.conversations.ui.UiCallback;
+
+public interface BasePgpEngine {
+    void decrypt(final Message message, final UiCallback<Message> callback);
+
+    void encrypt(final Message message, final UiCallback<Message> callback);
+
+    long fetchKeyId(Account account, String status, String signature);
+
+    void chooseKey(final Account account, final UiCallback<Account> callback);
+
+    void hasKey(final Contact contact, final UiCallback<Contact> callback);
+
+    PendingIntent getIntentForKey(Contact contact);
+    PendingIntent getIntentForKey(Account account, long pgpKeyId);
+}

--- a/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
+++ b/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
@@ -115,7 +115,9 @@ public class PgpDecryptionService {
 
 					@Override
 					public void userInputRequried(PendingIntent pi, Message message) {
-						messages.get(uuid).add(0, message);
+						// add message to the end of the list, to prevent an erroneous message
+						// from preventing the decryption of any futher messages
+						messages.get(uuid).add(message);
 						decryptingMessages.put(uuid, false);
 					}
 

--- a/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
+++ b/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
@@ -1,6 +1,7 @@
 package eu.siacs.conversations.crypto;
 
 import android.app.PendingIntent;
+import android.util.Log;
 
 import eu.siacs.conversations.entities.Message;
 import eu.siacs.conversations.services.XmppConnectionService;
@@ -109,7 +110,8 @@ public class PgpDecryptionService {
 				}
 			}
 			if (message != null && xmppConnectionService.getPgpEngine() != null) {
-				xmppConnectionService.getPgpEngine().decrypt(message, new UiCallback<Message>() {
+				// TODO: PHILIP Change to allow both engines
+				xmppConnectionService.getOxPgpEngine().decrypt(message, new UiCallback<Message>() {
 
 					@Override
 					public void userInputRequried(PendingIntent pi, Message message) {
@@ -125,6 +127,7 @@ public class PgpDecryptionService {
 
 					@Override
 					public void error(int error, Message message) {
+						Log.d("PHILIP", "pgpDecryptionService: failed" + message.getStatus());
 						message.setEncryption(Message.ENCRYPTION_DECRYPTION_FAILED);
 						xmppConnectionService.updateConversationUi();
 						decryptMessage(uuid);
@@ -138,7 +141,7 @@ public class PgpDecryptionService {
 
 	private void decryptDirectly(final Message message) {
 		if (message.getEncryption() == Message.ENCRYPTION_PGP && xmppConnectionService.getPgpEngine() != null) {
-			xmppConnectionService.getPgpEngine().decrypt(message, new UiCallback<Message>() {
+			xmppConnectionService.getOxPgpEngine().decrypt(message, new UiCallback<Message>() {
 
 				@Override
 				public void userInputRequried(PendingIntent pi, Message message) {
@@ -153,6 +156,7 @@ public class PgpDecryptionService {
 
 				@Override
 				public void error(int error, Message message) {
+					Log.d("PHILIP", "pgpDecryptionService: failed" + message.getStatus());
 					message.setEncryption(Message.ENCRYPTION_DECRYPTION_FAILED);
 					xmppConnectionService.updateConversationUi();
 				}

--- a/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
+++ b/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
@@ -100,7 +100,7 @@ public class PgpDecryptionService {
 		Message message = null;
 		synchronized (messages.get(uuid)) {
 			while (!messages.get(uuid).isEmpty()) {
-				if (messages.get(uuid).get(0).isAnyPgp()) {
+				if (messages.get(uuid).get(0).isStillEncryptedPgp()) {
 					if (isRunning()) {
 						message = messages.get(uuid).remove(0);
 					}
@@ -113,6 +113,7 @@ public class PgpDecryptionService {
 
 					@Override
 					public void userInputRequried(PendingIntent pi, Message message) {
+						// TODO: PHILIP is this necessary
 						// add message to the end of the list, to prevent an erroneous message
 						// from preventing the decryption of any further messages
 						messages.get(uuid).add(message);
@@ -121,6 +122,7 @@ public class PgpDecryptionService {
 
 					@Override
 					public void success(Message message) {
+						Log.d("PHILIP", "PgpDecryptionService decryptMessage success!");
 						xmppConnectionService.updateConversationUi();
 						decryptMessage(uuid);
 					}
@@ -129,6 +131,7 @@ public class PgpDecryptionService {
 					public void error(int error, Message message) {
 						Log.d("PHILIP", "pgpDecryptionService: failed - status" + message.getStatus());
 						message.setAppropriateEncryptionFailed();
+						message.setDecryptionFailureReason(error);
 						xmppConnectionService.updateConversationUi();
 						decryptMessage(uuid);
 					}
@@ -158,7 +161,7 @@ public class PgpDecryptionService {
 
 			@Override
 			public void error(int error, Message message) {
-				Log.d("PHILIP", "pgpDecryptionService: failed" + message.getStatus());
+				Log.d("PHILIP", "pgpDecryptionService: failed " + message.getStatus());
 				message.setAppropriateEncryptionFailed();
 				xmppConnectionService.updateConversationUi();
 			}

--- a/src/main/java/eu/siacs/conversations/crypto/Xep27PgpEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/Xep27PgpEngine.java
@@ -131,7 +131,6 @@ public class Xep27PgpEngine implements BasePgpEngine {
 		}
 	}
 
-	@Override
 	public void encrypt(final Message message, final UiCallback<Message> callback) {
 		Intent params = new Intent();
 		params.setAction(OpenPgpApi.ACTION_ENCRYPT);

--- a/src/main/java/eu/siacs/conversations/crypto/Xep27PgpEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/Xep27PgpEngine.java
@@ -28,15 +28,16 @@ import eu.siacs.conversations.persistance.FileBackend;
 import eu.siacs.conversations.services.XmppConnectionService;
 import eu.siacs.conversations.ui.UiCallback;
 
-public class PgpEngine {
+public class Xep27PgpEngine implements BasePgpEngine {
 	private OpenPgpApi api;
 	private XmppConnectionService mXmppConnectionService;
 
-	public PgpEngine(OpenPgpApi api, XmppConnectionService service) {
+	public Xep27PgpEngine(OpenPgpApi api, XmppConnectionService service) {
 		this.api = api;
 		this.mXmppConnectionService = service;
 	}
 
+	@Override
 	public void decrypt(final Message message,
 			final UiCallback<Message> callback) {
 		Intent params = new Intent();
@@ -104,7 +105,7 @@ public class PgpEngine {
 							URL url = message.getFileParams().url;
 							mXmppConnectionService.getFileBackend().updateFileParams(message,url);
 							message.setEncryption(Message.ENCRYPTION_DECRYPTED);
-							PgpEngine.this.mXmppConnectionService
+							Xep27PgpEngine.this.mXmppConnectionService
 									.updateMessage(message);
 							inputFile.delete();
 							Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
@@ -130,6 +131,7 @@ public class PgpEngine {
 		}
 	}
 
+	@Override
 	public void encrypt(final Message message, final UiCallback<Message> callback) {
 		Intent params = new Intent();
 		params.setAction(OpenPgpApi.ACTION_ENCRYPT);
@@ -234,6 +236,7 @@ public class PgpEngine {
 		}
 	}
 
+	@Override
 	public long fetchKeyId(Account account, String status, String signature) {
 		if ((signature == null) || (api == null)) {
 			return 0;
@@ -278,6 +281,7 @@ public class PgpEngine {
 		return 0;
 	}
 
+	@Override
 	public void chooseKey(final Account account, final UiCallback<Account> callback) {
 		Intent p = new Intent();
 		p.setAction(OpenPgpApi.ACTION_GET_SIGN_KEY_ID);
@@ -357,6 +361,7 @@ public class PgpEngine {
 		});
 	}
 
+	@Override
 	public void hasKey(final Contact contact, final UiCallback<Contact> callback) {
 		Intent params = new Intent();
 		params.setAction(OpenPgpApi.ACTION_GET_KEY);
@@ -381,6 +386,7 @@ public class PgpEngine {
 		});
 	}
 
+	@Override
 	public PendingIntent getIntentForKey(Contact contact) {
 		Intent params = new Intent();
 		params.setAction(OpenPgpApi.ACTION_GET_KEY);
@@ -390,6 +396,7 @@ public class PgpEngine {
 				.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
 	}
 
+	@Override
 	public PendingIntent getIntentForKey(Account account, long pgpKeyId) {
 		Intent params = new Intent();
 		params.setAction(OpenPgpApi.ACTION_GET_KEY);

--- a/src/main/java/eu/siacs/conversations/crypto/oxpgp/Constants.java
+++ b/src/main/java/eu/siacs/conversations/crypto/oxpgp/Constants.java
@@ -1,0 +1,8 @@
+package eu.siacs.conversations.crypto.oxpgp;
+
+/**
+ * Created by abrahamphilip on 13/2/16.
+ */
+public class Constants {
+    public static final String PGP_NS = "urn:xmpp:openpgp:0";
+}

--- a/src/main/java/eu/siacs/conversations/crypto/oxpgp/OxPgpEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/oxpgp/OxPgpEngine.java
@@ -1,0 +1,363 @@
+package eu.siacs.conversations.crypto.oxpgp;
+
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import org.openintents.openpgp.util.OpenPgpApi;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Random;
+import java.util.TimeZone;
+
+import eu.siacs.conversations.R;
+import eu.siacs.conversations.entities.Account;
+import eu.siacs.conversations.entities.Conversation;
+import eu.siacs.conversations.entities.DownloadableFile;
+import eu.siacs.conversations.entities.Message;
+import eu.siacs.conversations.http.HttpConnectionManager;
+import eu.siacs.conversations.persistance.FileBackend;
+import eu.siacs.conversations.services.XmppConnectionService;
+import eu.siacs.conversations.ui.UiCallback;
+import eu.siacs.conversations.xml.Element;
+import eu.siacs.conversations.xml.Tag;
+import eu.siacs.conversations.xml.XmlReader;
+import eu.siacs.conversations.xmpp.jid.Jid;
+
+/**
+ * Created by abrahamphilip on 6/2/16.
+ */
+public class OxPgpEngine {
+    private OpenPgpApi mApi;
+    private XmppConnectionService mXmppConnectionService;
+
+    public static final String ELEMENT_SIGNCRYPT_NAME = "signcrypt";
+    public static final String ELEMENT_SIGNCRYPT_NS = "urn:xmpp:openpgp:0";
+    public static final String ELEMENT_OPENPGP_NAME = "openpgp";
+    public static final String ELEMENT_OPENPGP_NS = "urn:xmpp:openpgp:0";
+    public static final String ELEMENT_PAYLOAD_NAME = "payload";
+    public static final String ELEMENT_PAYLOAD_BODY_NAME = "body";
+    public static final String ELEMENT_PAYLOAD_BODY_NS = "jabber:client";
+
+    private static final int RPAD_MAX_LENGTH = 50;
+
+    private final String TAG = "OxPgpEngine";
+
+    public OxPgpEngine(OpenPgpApi api, XmppConnectionService service) {
+        this.mApi = api;
+        this.mXmppConnectionService = service;
+    }
+
+
+    public void encrypt(final Message message, final UiCallback<Message> callback) {
+        Intent params = new Intent();
+        params.setAction(OpenPgpApi.ACTION_ENCRYPT);
+        final Conversation conversation = message.getConversation();
+        if (conversation.getMode() == Conversation.MODE_SINGLE) {
+            long[] keys = {
+                    conversation.getContact().getPgpKeyId(),
+                    conversation.getAccount().getPgpId()
+            };
+            params.putExtra(OpenPgpApi.EXTRA_KEY_IDS, keys);
+        } else {
+            //params.putExtra(OpenPgpApi.EXTRA_KEY_IDS, conversation.getMucOptions().getPgpKeyIds());
+            throw new UnsupportedOperationException("OXPGP does not support MUC yet");
+        }
+
+        if (!message.needsUploading()) {
+            params.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
+            final String toEncryptBody = getSingCryptPacket(message);
+
+            InputStream is = new ByteArrayInputStream(toEncryptBody.getBytes());
+            final OutputStream os = new ByteArrayOutputStream();
+            mApi.executeApiAsync(params, is, os, new OpenPgpApi.IOpenPgpCallback() {
+
+                @Override
+                public void onReturn(Intent result) {
+                    notifyPgpDecryptionService(message.getConversation().getAccount(), OpenPgpApi.ACTION_ENCRYPT, result);
+                    switch (result.getIntExtra(OpenPgpApi.RESULT_CODE,
+                            OpenPgpApi.RESULT_CODE_ERROR)) {
+                        case OpenPgpApi.RESULT_CODE_SUCCESS:
+                            try {
+                                os.flush();
+                                StringBuilder encryptedMessageBody = new StringBuilder();
+                                String[] lines = os.toString().split("\n");
+                                for (int i = 2; i < lines.length - 1; ++i) {
+                                    if (!lines[i].contains("Version")) {
+                                        encryptedMessageBody.append(lines[i].trim());
+                                    }
+                                }
+                                message.setEncryptedBody(encryptedMessageBody.toString());
+                                callback.success(message);
+                            } catch (IOException e) {
+                                callback.error(R.string.openpgp_error, message);
+                            }
+
+                            break;
+                        case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+                            callback.userInputRequried((PendingIntent) result
+                                            .getParcelableExtra(OpenPgpApi.RESULT_INTENT),
+                                    message);
+                            break;
+                        case OpenPgpApi.RESULT_CODE_ERROR:
+                            callback.error(R.string.openpgp_error, message);
+                            break;
+                    }
+                }
+            });
+        } else {
+            try {
+                DownloadableFile inputFile = this.mXmppConnectionService
+                        .getFileBackend().getFile(message, true);
+                DownloadableFile outputFile = this.mXmppConnectionService
+                        .getFileBackend().getFile(message, false);
+                outputFile.getParentFile().mkdirs();
+                outputFile.createNewFile();
+                final InputStream is = new FileInputStream(inputFile);
+                final OutputStream os = new FileOutputStream(outputFile);
+                mApi.executeApiAsync(params, is, os, new OpenPgpApi.IOpenPgpCallback() {
+
+                    @Override
+                    public void onReturn(Intent result) {
+                        notifyPgpDecryptionService(message.getConversation().getAccount(), OpenPgpApi.ACTION_ENCRYPT, result);
+                        switch (result.getIntExtra(OpenPgpApi.RESULT_CODE,
+                                OpenPgpApi.RESULT_CODE_ERROR)) {
+                            case OpenPgpApi.RESULT_CODE_SUCCESS:
+                                try {
+                                    os.flush();
+                                } catch (IOException ignored) {
+                                    //ignored
+                                }
+                                FileBackend.close(os);
+                                callback.success(message);
+                                break;
+                            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+                                callback.userInputRequried(
+                                        (PendingIntent) result
+                                                .getParcelableExtra(OpenPgpApi.RESULT_INTENT),
+                                        message);
+                                break;
+                            case OpenPgpApi.RESULT_CODE_ERROR:
+                                callback.error(R.string.openpgp_error, message);
+                                break;
+                        }
+                    }
+                });
+            } catch (final IOException e) {
+                callback.error(R.string.openpgp_error, message);
+            }
+        }
+    }
+
+    private String getSingCryptPacket(Message message) {
+        String body;
+        if (message.hasFileOnRemoteHost()) {
+            body = message.getFileParams().url.toString();
+        } else {
+            body = message.getBody();
+        }
+        Element signCryptElement = new Element(ELEMENT_SIGNCRYPT_NAME, ELEMENT_SIGNCRYPT_NS);
+
+        // to element MUST have a jid attribute which SHOULD be a bare JID
+        Jid toJid = message.getConversation().getJid().toBareJid();
+        Element toElement = new Element("to");
+        toElement.setAttribute("jid", toJid.getLocalpart() + "@" + toJid.getDomainpart());
+
+        // timestamp is a MUST
+        Date currDate = Calendar.getInstance().getTime();
+        String date = new SimpleDateFormat("yyyy-MM-dd", Locale.US).format(currDate);
+        String time = new SimpleDateFormat("HH:mm:ss.SSSZZZZZ", Locale.US).format(currDate);
+        Element timestampEle = new Element("time");
+        timestampEle.setAttribute("stamp", date + "T" + time);
+
+        // rpad is a SHOULD, to prevent determination of message length
+        Element rpadEle = new Element("rpad");
+        rpadEle.setContent(getRandomPadding());
+        Log.d("PHILIP", "rpad:" + rpadEle.getContent());
+
+        // payload contains stanza extension elements which would normally be considered children
+        // of an unencrypted message
+        Element payLoadEle = new Element(ELEMENT_PAYLOAD_NAME);
+        Element bodyEle = new Element(ELEMENT_PAYLOAD_BODY_NAME, ELEMENT_PAYLOAD_BODY_NS);
+        bodyEle.setContent(body);
+        payLoadEle.addChild(bodyEle);
+
+        signCryptElement.addChild(toElement);
+        signCryptElement.addChild(timestampEle);
+        signCryptElement.addChild(rpadEle);
+        signCryptElement.addChild(payLoadEle);
+
+        return signCryptElement.toString();
+    }
+
+    private void notifyPgpDecryptionService(Account account, String action, final Intent result) {
+        switch (result.getIntExtra(OpenPgpApi.RESULT_CODE, 0)) {
+            case OpenPgpApi.RESULT_CODE_SUCCESS:
+                if (OpenPgpApi.ACTION_SIGN.equals(action)) {
+                    account.getPgpDecryptionService().onKeychainUnlocked();
+                }
+                break;
+            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+                account.getPgpDecryptionService().onKeychainLocked();
+                break;
+        }
+    }
+
+    /**
+     * this is to prevent approximation of message length, which can be used to detect short
+     * messages like yes or no
+     *
+     * @return random length string
+     */
+    private static String getRandomPadding() {
+        Random generator = new Random();
+        StringBuilder randomStringBuilder = new StringBuilder();
+        int randomLength = generator.nextInt(RPAD_MAX_LENGTH);
+        // TODO: does repChar really need to be random?
+        char repChar = 'a';
+        for (int i = 0; i < randomLength; i++) {
+            randomStringBuilder.append(repChar);
+        }
+        return randomStringBuilder.toString();
+    }
+
+    /**
+     * Expects message body to be set to the contents of the <openpgp> tag
+     *
+     * @param message
+     * @param callback
+     */
+    public void decrypt(final Message message,
+                        final UiCallback<Message> callback) {
+        Intent params = new Intent();
+        params.setAction(OpenPgpApi.ACTION_DECRYPT_VERIFY);
+        if (message.getType() == Message.TYPE_TEXT) {
+            InputStream is = new ByteArrayInputStream(message.getBody().getBytes());
+            final OutputStream os = new ByteArrayOutputStream();
+
+            mApi.executeApiAsync(params, is, os, new OpenPgpApi.IOpenPgpCallback() {
+
+                @Override
+                public void onReturn(Intent result) {
+                    notifyPgpDecryptionService(message.getConversation().getAccount(),
+                            OpenPgpApi.ACTION_DECRYPT_VERIFY, result);
+                    switch (result.getIntExtra(OpenPgpApi.RESULT_CODE,
+                            OpenPgpApi.RESULT_CODE_ERROR)) {
+                        case OpenPgpApi.RESULT_CODE_SUCCESS:
+                            try {
+                                os.flush();
+                                if (message.getEncryption() == Message.ENCRYPTION_PGP) {
+                                    message.setBody(extractBody(os.toString()));
+                                    message.setEncryption(Message.ENCRYPTION_DECRYPTED);
+                                    final HttpConnectionManager manager = mXmppConnectionService.getHttpConnectionManager();
+                                    if (message.trusted()
+                                            && message.treatAsDownloadable() != Message.Decision.NEVER
+                                            && manager.getAutoAcceptFileSize() > 0) {
+                                        manager.createNewDownloadConnection(message);
+                                    }
+                                    mXmppConnectionService.updateMessage(message);
+                                    callback.success(message);
+                                }
+                            } catch (IOException | XmlPullParserException e) {
+                                callback.error(R.string.openpgp_error, message);
+                                return;
+                            }
+
+                            return;
+                        case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+                            callback.userInputRequried((PendingIntent) result
+                                            .getParcelableExtra(OpenPgpApi.RESULT_INTENT),
+                                    message);
+                            return;
+                        case OpenPgpApi.RESULT_CODE_ERROR:
+                            callback.error(R.string.openpgp_error, message);
+                    }
+                }
+            });
+        } else if (message.getType() == Message.TYPE_IMAGE || message.getType() == Message.TYPE_FILE) {
+            // TODO: PHILIP get this working
+            throw new UnsupportedOperationException("Images and files not handled yet");
+            /*
+            try {
+                final DownloadableFile inputFile = this.mXmppConnectionService
+                        .getFileBackend().getFile(message, false);
+                final DownloadableFile outputFile = this.mXmppConnectionService
+                        .getFileBackend().getFile(message, true);
+                outputFile.getParentFile().mkdirs();
+                outputFile.createNewFile();
+                InputStream is = new FileInputStream(inputFile);
+                OutputStream os = new FileOutputStream(outputFile);
+                mApi.executeApiAsync(params, is, os, new OpenPgpApi.IOpenPgpCallback() {
+
+                    @Override
+                    public void onReturn(Intent result) {
+                        notifyPgpDecryptionService(message.getConversation().getAccount(), OpenPgpApi.ACTION_DECRYPT_VERIFY, result);
+                        switch (result.getIntExtra(OpenPgpApi.RESULT_CODE,
+                                OpenPgpApi.RESULT_CODE_ERROR)) {
+                            case OpenPgpApi.RESULT_CODE_SUCCESS:
+                                URL url = message.getFileParams().url;
+                                mXmppConnectionService.getFileBackend().updateFileParams(message,url);
+                                message.setEncryption(Message.ENCRYPTION_DECRYPTED);
+                                OxPgpEngine.this.mXmppConnectionService
+                                        .updateMessage(message);
+                                inputFile.delete();
+                                Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                                intent.setData(Uri.fromFile(outputFile));
+                                mXmppConnectionService.sendBroadcast(intent);
+                                callback.success(message);
+                                return;
+                            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+                                callback.userInputRequried(
+                                        (PendingIntent) result
+                                                .getParcelableExtra(OpenPgpApi.RESULT_INTENT),
+                                        message);
+                                return;
+                            case OpenPgpApi.RESULT_CODE_ERROR:
+                                callback.error(R.string.openpgp_error, message);
+                        }
+                    }
+                });
+            } catch (final IOException e) {
+                callback.error(R.string.error_decrypting_file, message);
+            }
+                */
+
+        }
+    }
+
+    protected @NonNull String extractBody(String openpgpElement) throws IOException,
+            XmlPullParserException {
+        XmlReader tagReader = new XmlReader();
+        Log.d("PHILIP", "body extraction:" + openpgpElement);
+        InputStream is = new ByteArrayInputStream(openpgpElement.getBytes());
+        tagReader.setInputStream(is);
+        Tag openpgp = tagReader.readTag();
+        Element signCrypt = tagReader.readElement(openpgp);
+        if (signCrypt == null) {
+            throw new XmlPullParserException("No signcrypt element!");
+        }
+        Element payload = signCrypt.findChild(ELEMENT_PAYLOAD_NAME);
+        if (payload == null) {
+            throw new XmlPullParserException("No payload element inside signcrypt!");
+        }
+        Element nestedBody = payload.findChild(ELEMENT_PAYLOAD_BODY_NAME);
+        if (nestedBody == null) {
+            throw new XmlPullParserException("No body inside payload element!");
+        }
+        return nestedBody.getContent();
+    }
+}

--- a/src/main/java/eu/siacs/conversations/entities/Account.java
+++ b/src/main/java/eu/siacs/conversations/entities/Account.java
@@ -462,6 +462,19 @@ public class Account extends AbstractEntity {
 		return true;
 	}
 
+	public long getOxPgpId() {
+		// TODO: PHILIP make it return actual key
+		if (keys.has(KEY_PGP_ID)) {
+			try {
+				return keys.getLong(KEY_PGP_ID);
+			} catch (JSONException e) {
+				return -1;
+			}
+		} else {
+			return -1;
+		}
+	}
+
 	public Roster getRoster() {
 		return this.roster;
 	}

--- a/src/main/java/eu/siacs/conversations/entities/Contact.java
+++ b/src/main/java/eu/siacs/conversations/entities/Contact.java
@@ -354,6 +354,21 @@ public class Contact implements ListItem, Blockable {
 		}
 	}
 
+	public long getOxPgpKeyId() {
+		// TODO: PHILIP change to OX
+		synchronized (this.keys) {
+			if (this.keys.has("pgp_keyid")) {
+				try {
+					return this.keys.getLong("pgp_keyid");
+				} catch (JSONException e) {
+					return 0;
+				}
+			} else {
+				return 0;
+			}
+		}
+	}
+
 	public void setOption(int option) {
 		this.subscription |= 1 << option;
 	}

--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -596,12 +596,7 @@ public class Conversation extends AbstractEntity implements Blockable {
 			for(int i = this.messages.size() -1; i >= 0; --i) {
 				final Message m = this.messages.get(i);
 				if (!m.isCarbon() && m.getStatus() != Message.STATUS_RECEIVED) {
-					final int e = m.getEncryption();
-					if (e == Message.ENCRYPTION_DECRYPTED || e == Message.ENCRYPTION_DECRYPTION_FAILED) {
-						return Message.ENCRYPTION_PGP;
-					} else {
-						return e;
-					}
+					return m.getEncryptionBeforeDecryption();
 				}
 			}
 		}
@@ -613,12 +608,7 @@ public class Conversation extends AbstractEntity implements Blockable {
 			for(int i = this.messages.size() -1; i >= 0; --i) {
 				final Message m = this.messages.get(i);
 				if (m.getStatus() == Message.STATUS_RECEIVED) {
-					final int e = m.getEncryption();
-					if (e == Message.ENCRYPTION_DECRYPTED || e == Message.ENCRYPTION_DECRYPTION_FAILED) {
-						return Message.ENCRYPTION_PGP;
-					} else {
-						return e;
-					}
+					return m.getEncryptionBeforeDecryption();
 				}
 			}
 		}

--- a/src/main/java/eu/siacs/conversations/entities/Message.java
+++ b/src/main/java/eu/siacs/conversations/entities/Message.java
@@ -37,6 +37,7 @@ public class Message extends AbstractEntity {
 	public static final int ENCRYPTION_DECRYPTION_FAILED = 4;
 	public static final int ENCRYPTION_AXOLOTL = 5;
 	public static final int ENCRYPTION_PGP_OX = 6;
+	public static final int ENCRYPTION_OX_DECRYPTED = 7;
 
 	public static final int TYPE_TEXT = 0;
 	public static final int TYPE_IMAGE = 1;

--- a/src/main/java/eu/siacs/conversations/entities/Message.java
+++ b/src/main/java/eu/siacs/conversations/entities/Message.java
@@ -27,7 +27,7 @@ public class Message extends AbstractEntity {
 	public static final int STATUS_SEND_FAILED = 3;
 	public static final int STATUS_WAITING = 5;
 	public static final int STATUS_OFFERED = 6;
-	public static final int STATUS_SEND_RECEIVED = 7;
+	public static final int STATUS_SEND_RECEIVED = 7; // TODO: Diff b/w this and status_received
 	public static final int STATUS_SEND_DISPLAYED = 8;
 
 	public static final int ENCRYPTION_NONE = 0;
@@ -36,6 +36,7 @@ public class Message extends AbstractEntity {
 	public static final int ENCRYPTION_DECRYPTED = 3;
 	public static final int ENCRYPTION_DECRYPTION_FAILED = 4;
 	public static final int ENCRYPTION_AXOLOTL = 5;
+	public static final int ENCRYPTION_PGP_OX = 6;
 
 	public static final int TYPE_TEXT = 0;
 	public static final int TYPE_IMAGE = 1;

--- a/src/main/java/eu/siacs/conversations/generator/IqGenerator.java
+++ b/src/main/java/eu/siacs/conversations/generator/IqGenerator.java
@@ -17,6 +17,8 @@ import java.util.Set;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.crypto.axolotl.AxolotlService;
+import eu.siacs.conversations.crypto.oxpgp.Constants;
+import eu.siacs.conversations.crypto.oxpgp.OxPgpEngine;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Conversation;
 import eu.siacs.conversations.entities.DownloadableFile;
@@ -49,6 +51,7 @@ public class IqGenerator extends AbstractGenerator {
 		identity.setAttribute("name", getIdentityName());
 		for (final String feature : getFeatures()) {
 			query.addChild("feature").setAttribute("var", feature);
+			Log.d("PHILIP", "feature discovery:" + feature);
 		}
 		return packet;
 	}
@@ -333,5 +336,23 @@ public class IqGenerator extends AbstractGenerator {
 		data.put("secret",secret);
 		enable.addChild(data);
 		return packet;
+	}
+
+	public IqPacket getPublishOxPgpFeature(Account account) {
+		// TODO: PHILIP
+		IqPacket packet = new IqPacket(IqPacket.TYPE.SET);
+
+		packet.setTo(account.getServer());
+		packet.query("http://jabber.org/protocol/disco#info")
+				.addChild("feature").setAttribute("var", "urn:xmpp:openpgp:0");
+
+		return packet;
+	}
+
+	public IqPacket getPublishOxPgpPublicKey(Account account, String base64PubKey) {
+		Element pubKeys = new Element("pubkeys", Constants.PGP_NS)
+				.addChild(new Element("pubkey").setContent(base64PubKey));
+
+		return publish("urn:xmpp:openpgp:0", pubKeys);
 	}
 }

--- a/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
+++ b/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
@@ -1,5 +1,7 @@
 package eu.siacs.conversations.generator;
 
+import android.util.Log;
+
 import net.java.otr4j.OtrException;
 import net.java.otr4j.session.Session;
 
@@ -118,6 +120,20 @@ public class MessageGenerator extends AbstractGenerator {
 			packet.addChild("x", "jabber:x:encrypted").setContent(message.getEncryptedBody());
 		} else if (message.getEncryption() == Message.ENCRYPTION_PGP) {
 			packet.addChild("x", "jabber:x:encrypted").setContent(message.getBody());
+		}
+		return packet;
+	}
+
+	public MessagePacket generateOxPgpChat(Message message) {
+		MessagePacket packet = preparePacket(message);
+		packet.setBody("This is an OpenPGP encrypted message.");
+		if (message.getEncryption() == Message.ENCRYPTION_DECRYPTED) {
+			Log.d("PHILIP", "encrypted body" + message.getEncryptedBody());
+			packet.addChild("openpgp", "urn:xmpp:openpgp:0").setContent(message.getEncryptedBody());
+		} else if (message.getEncryption() == Message.ENCRYPTION_PGP) {
+			// TODO: When does this happen?
+			Log.d("PHILIP", "just body" + message.getBody());
+			packet.addChild("openpgp", "urn:xmpp:openpgp:0").setContent(message.getBody());
 		}
 		return packet;
 	}

--- a/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
+++ b/src/main/java/eu/siacs/conversations/generator/MessageGenerator.java
@@ -127,10 +127,11 @@ public class MessageGenerator extends AbstractGenerator {
 	public MessagePacket generateOxPgpChat(Message message) {
 		MessagePacket packet = preparePacket(message);
 		packet.setBody("This is an OpenPGP encrypted message.");
-		if (message.getEncryption() == Message.ENCRYPTION_DECRYPTED) {
+		if (message.getEncryption() == Message.ENCRYPTION_DECRYPTED_OX) {
 			Log.d("PHILIP", "encrypted body" + message.getEncryptedBody());
 			packet.addChild("openpgp", "urn:xmpp:openpgp:0").setContent(message.getEncryptedBody());
-		} else if (message.getEncryption() == Message.ENCRYPTION_PGP) {
+			Log.d("PHILIP", "final message packet oxpgp" + packet);
+		} else if (message.getEncryption() == Message.ENCRYPTION_PGP_OX) {
 			// TODO: When does this happen?
 			Log.d("PHILIP", "just body" + message.getBody());
 			packet.addChild("openpgp", "urn:xmpp:openpgp:0").setContent(message.getBody());

--- a/src/main/java/eu/siacs/conversations/http/HttpUploadConnection.java
+++ b/src/main/java/eu/siacs/conversations/http/HttpUploadConnection.java
@@ -12,10 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.Proxy;
 import java.net.URL;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -202,7 +199,7 @@ public class HttpUploadConnection implements Transferable {
 					message.setTransferable(null);
 					message.setCounterpart(message.getConversation().getJid().toBareJid());
 					if (message.getEncryption() == Message.ENCRYPTION_DECRYPTED) {
-						mXmppConnectionService.getPgpEngine().encrypt(message, new UiCallback<Message>() {
+						mXmppConnectionService.getXep27PgpEngine().encrypt(message, new UiCallback<Message>() {
 							@Override
 							public void success(Message message) {
 								mXmppConnectionService.resendMessage(message,delayed);

--- a/src/main/java/eu/siacs/conversations/parser/MessageParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/MessageParser.java
@@ -128,9 +128,8 @@ public class MessageParser extends AbstractParser implements
 	private Message parseOxPGPChat(final Conversation conversation, String openPgpEleContents,
 								   int status) {
 		Log.d("PHILIP", "parseOXPGP body: " + openPgpEleContents);
-		// TODO: PHILIP Change to ENCRYPTION_OXPGP
 		final Message message = new Message(conversation, openPgpEleContents,
-				Message.ENCRYPTION_PGP, status);
+				Message.ENCRYPTION_PGP_OX, status);
 		PgpDecryptionService pgpDecryptionService = conversation.getAccount()
 				.getPgpDecryptionService();
 		pgpDecryptionService.add(message);
@@ -264,7 +263,7 @@ public class MessageParser extends AbstractParser implements
 				+ original.getFrom());
 		for(Element e: original.getChildren()) {
 			Log.d("PHILIP", "Message packet: <" + e.getName() + " xmlns=" + e.getNamespace() + "> "
-					+ e.getContent());
+					+ e.getContent() + "\n</" + e.getName() + ">");
 		}
 		if (handleErrorMessage(account, original)) {
 			return;

--- a/src/main/java/eu/siacs/conversations/parser/MessageParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/MessageParser.java
@@ -127,6 +127,7 @@ public class MessageParser extends AbstractParser implements
 
 	private Message parseOxPGPChat(final Conversation conversation, String openPgpEleContents,
 								   int status) {
+		Log.d("PHILIP", "parseOXPGP body: " + openPgpEleContents);
 		// TODO: PHILIP Change to ENCRYPTION_OXPGP
 		final Message message = new Message(conversation, openPgpEleContents,
 				Message.ENCRYPTION_PGP, status);

--- a/src/main/java/eu/siacs/conversations/parser/PresenceParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/PresenceParser.java
@@ -7,22 +7,19 @@ import java.util.List;
 
 
 import eu.siacs.conversations.Config;
-import eu.siacs.conversations.crypto.PgpEngine;
+import eu.siacs.conversations.crypto.Xep27PgpEngine;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Contact;
 import eu.siacs.conversations.entities.Conversation;
 import eu.siacs.conversations.entities.Message;
 import eu.siacs.conversations.entities.MucOptions;
 import eu.siacs.conversations.entities.Presence;
-import eu.siacs.conversations.entities.ServiceDiscoveryResult;
 import eu.siacs.conversations.generator.PresenceGenerator;
 import eu.siacs.conversations.services.XmppConnectionService;
 import eu.siacs.conversations.xml.Element;
-import eu.siacs.conversations.xmpp.OnIqPacketReceived;
 import eu.siacs.conversations.xmpp.OnPresencePacketReceived;
 import eu.siacs.conversations.xmpp.jid.Jid;
 import eu.siacs.conversations.xmpp.pep.Avatar;
-import eu.siacs.conversations.xmpp.stanzas.IqPacket;
 import eu.siacs.conversations.xmpp.stanzas.PresencePacket;
 
 public class PresenceParser extends AbstractParser implements
@@ -80,12 +77,12 @@ public class PresenceParser extends AbstractParser implements
 						} else {
 							mucOptions.addUser(user);
 						}
-						if (mXmppConnectionService.getPgpEngine() != null) {
+						if (mXmppConnectionService.getXep27PgpEngine() != null) {
 							Element signed = packet.findChild("x", "jabber:x:signed");
 							if (signed != null) {
 								Element status = packet.findChild("status");
 								String msg = status == null ? "" : status.getContent();
-								long keyId = mXmppConnectionService.getPgpEngine().fetchKeyId(mucOptions.getAccount(), msg, signed.getContent());
+								long keyId = mXmppConnectionService.getXep27PgpEngine().fetchKeyId(mucOptions.getAccount(), msg, signed.getContent());
 								if (keyId != 0) {
 									user.setPgpKeyId(keyId);
 								}
@@ -194,7 +191,7 @@ public class PresenceParser extends AbstractParser implements
 				mXmppConnectionService.fetchCaps(account, from, presence);
 			}
 
-			PgpEngine pgp = mXmppConnectionService.getPgpEngine();
+			Xep27PgpEngine pgp = mXmppConnectionService.getXep27PgpEngine();
 			Element x = packet.findChild("x", "jabber:x:signed");
 			if (pgp != null && x != null) {
 				Element status = packet.findChild("status");

--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -51,7 +51,7 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 	private static DatabaseBackend instance = null;
 
 	private static final String DATABASE_NAME = "history";
-	private static final int DATABASE_VERSION = 23;
+	private static final int DATABASE_VERSION = 24;
 
 	private static String CREATE_CONTATCS_STATEMENT = "create table "
 			+ Contact.TABLENAME + "(" + Contact.ACCOUNT + " TEXT, "
@@ -162,6 +162,7 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 				+ Message.FINGERPRINT + " TEXT, "
 				+ Message.CARBON + " INTEGER, "
 				+ Message.READ + " NUMBER DEFAULT 1, "
+				+ Message.REASON_DECRYPTION_FAILED + " INTEGER DEFAULT -1, "
 				+ Message.REMOTE_MSG_ID + " TEXT, FOREIGN KEY("
 				+ Message.CONVERSATION + ") REFERENCES "
 				+ Conversation.TABLENAME + "(" + Conversation.UUID
@@ -369,6 +370,11 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 
 		if (oldVersion < 23 && newVersion >= 23) {
 			db.execSQL(CREATE_DISCOVERY_RESULTS_STATEMENT);
+		}
+
+		if (oldVersion < 24 && newVersion >= 24) {
+			db.execSQL("ALTER TABLE " + Message.TABLENAME + " ADD COLUMN "
+					+ Message.REASON_DECRYPTION_FAILED + " INTEGER DEFAULT -1");
 		}
 	}
 

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -64,6 +64,7 @@ import eu.siacs.conversations.R;
 import eu.siacs.conversations.crypto.PgpEngine;
 import eu.siacs.conversations.crypto.axolotl.AxolotlService;
 import eu.siacs.conversations.crypto.axolotl.XmppAxolotlMessage;
+import eu.siacs.conversations.crypto.oxpgp.OxPgpEngine;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Blockable;
 import eu.siacs.conversations.entities.Bookmark;
@@ -331,6 +332,7 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 	};
 	private OpenPgpServiceConnection pgpServiceConnection;
 	private PgpEngine mPgpEngine = null;
+	private OxPgpEngine mOxPgpEngine = null;
 	private WakeLock wakeLock;
 	private PowerManager pm;
 	private LruCache<String, Bitmap> mBitmapCache;
@@ -355,6 +357,20 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 						pgpServiceConnection.getService()), this);
 			}
 			return mPgpEngine;
+		} else {
+			return null;
+		}
+
+	}
+
+	public OxPgpEngine getOxPgpEngine() {
+		if (pgpServiceConnection.isBound()) {
+			if (this.mOxPgpEngine == null) {
+				this.mOxPgpEngine = new OxPgpEngine(new OpenPgpApi(
+						getApplicationContext(),
+						pgpServiceConnection.getService()), this);
+			}
+			return mOxPgpEngine;
 		} else {
 			return null;
 		}
@@ -879,7 +895,8 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 							break;
 						}
 					} else {
-						packet = mMessageGenerator.generatePgpChat(message);
+						//packet = mMessageGenerator.generatePgpChat(message);
+						packet = mMessageGenerator.generateOxPgpChat(message);
 					}
 					break;
 				case Message.ENCRYPTION_OTR:

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -379,7 +379,7 @@ public class XmppConnectionService extends Service implements OnPhoneContactsLoa
 	}
 
 	public @Nullable BasePgpEngine getPgpEngineFor(Message message) {
-		switch (message.getPgpType()) {
+		switch (message.getPgpEncryption()) {
 			case XEP27:
 				return getXep27PgpEngine();
 			case OX:

--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -6,7 +6,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.IntentSender.SendIntentException;
-import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.ContextMenu;
@@ -32,7 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
-import eu.siacs.conversations.crypto.PgpEngine;
+import eu.siacs.conversations.crypto.Xep27PgpEngine;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Bookmark;
 import eu.siacs.conversations.entities.Contact;
@@ -635,7 +634,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 	}
 
 	private void viewPgpKey(User user) {
-		PgpEngine pgp = xmppConnectionService.getPgpEngine();
+		Xep27PgpEngine pgp = xmppConnectionService.getXep27PgpEngine();
 		if (pgp != null) {
 			PendingIntent intent = pgp.getIntentForKey(
 					mConversation.getAccount(), user.getPgpKeyId());

--- a/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
@@ -14,7 +14,6 @@ import android.provider.ContactsContract;
 import android.provider.ContactsContract.CommonDataKinds;
 import android.provider.ContactsContract.Contacts;
 import android.provider.ContactsContract.Intents;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -37,7 +36,7 @@ import java.util.List;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
-import eu.siacs.conversations.crypto.PgpEngine;
+import eu.siacs.conversations.crypto.Xep27PgpEngine;
 import eu.siacs.conversations.crypto.axolotl.AxolotlService;
 import eu.siacs.conversations.crypto.axolotl.XmppAxolotlSession;
 import eu.siacs.conversations.entities.Account;
@@ -416,8 +415,8 @@ public class ContactDetailsActivity extends XmppActivity implements OnAccountUpd
 
 				@Override
 				public void onClick(View v) {
-					PgpEngine pgp = ContactDetailsActivity.this.xmppConnectionService
-						.getPgpEngine();
+					Xep27PgpEngine pgp = ContactDetailsActivity.this.xmppConnectionService
+						.getXep27PgpEngine();
 					if (pgp != null) {
 						PendingIntent intent = pgp.getIntentForKey(contact);
 						if (intent != null) {

--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -1514,6 +1514,30 @@ public class ConversationActivity extends XmppActivity
 				});
 	}
 
+	public void encryptTestMessageOxPgp(Message message) {
+		xmppConnectionService.getOxPgpEngine().encrypt(message,
+				new UiCallback<Message>() {
+
+					@Override
+					public void userInputRequried(PendingIntent pi,
+												  Message message) {
+						ConversationActivity.this.runIntent(pi,
+								ConversationActivity.REQUEST_SEND_MESSAGE);
+					}
+
+					@Override
+					public void success(Message message) {
+						message.setEncryption(Message.ENCRYPTION_DECRYPTED);
+						xmppConnectionService.sendMessage(message);
+					}
+
+					@Override
+					public void error(int error, Message message) {
+
+					}
+				});
+	}
+
 	public boolean useSendButtonToIndicateStatus() {
 		return getPreferences().getBoolean("send_button_status", false);
 	}

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -208,6 +208,7 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 	private final int KEYCHAIN_UNLOCK_REQUIRED = 1;
 	private final int KEYCHAIN_UNLOCK_PENDING = 2;
 	private int keychainUnlock = KEYCHAIN_UNLOCK_NOT_REQUIRED;
+	// this is shown for PGP and OXPGP decryption
 	protected OnClickListener clickToDecryptListener = new OnClickListener() {
 
 		@Override
@@ -218,7 +219,7 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 				updateSnackBar(conversation);
 				Message message = getLastPgpDecryptableMessage();
 				if (message != null) {
-					activity.xmppConnectionService.getPgpEngine().decrypt(message, new UiCallback<Message>() {
+					activity.xmppConnectionService.getOxPgpEngine().decrypt(message, new UiCallback<Message>() {
 						@Override
 						public void success(Message object) {
 							conversation.getAccount().getPgpDecryptionService().onKeychainUnlocked();

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -217,10 +217,10 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 					&& activity.hasPgp() && !conversation.getAccount().getPgpDecryptionService().isRunning()) {
 				keychainUnlock = KEYCHAIN_UNLOCK_PENDING;
 				updateSnackBar(conversation);
-				Message message = getLastPgpDecryptableMessage();
+				final Message message = getLastPgpDecryptableMessage();
 				if (message != null) {
 					final int REQUEST_CODE;
-					switch(message.getPgpType()) {
+					switch(message.getPgpEncryption()) {
 						case XEP27:
 							REQUEST_CODE = ConversationActivity.REQUEST_DECRYPT_PGP_XEP27;
 							break;
@@ -229,7 +229,8 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 							break;
 						default:
 							Log.e(Config.LOGTAG,
-									"Shouldn't have got a non PGP message here! Message Type: "
+									"clickToDecryptListener: Shouldn't have got a non PGP" +
+											" message here! Message Type: "
 											+ message.getType());
 							return;
 					}
@@ -243,6 +244,13 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 
 								@Override
 								public void error(int errorCode, Message object) {
+									// TODO: PHILIP get this working
+									showSnackbar(errorCode, R.string.ok, new OnClickListener() {
+										@Override
+										public void onClick(View v) {
+											// do nothing, just dismiss snackbar
+										}
+									});
 									keychainUnlock = KEYCHAIN_UNLOCK_NOT_REQUIRED;
 								}
 
@@ -868,7 +876,7 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 	@Nullable
 	private Message getLastPgpDecryptableMessage() {
 		for (final Message message : this.messageList) {
-			if (message.isAnyPgp()
+			if (message.isStillEncryptedPgp()
 					&& (message.getStatus() == Message.STATUS_RECEIVED || message.getStatus() >= Message.STATUS_SEND)
 					&& message.getTransferable() == null) {
 				return message;
@@ -1107,7 +1115,7 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 														  Contact contact) {
 								activity.runIntent(
 										pi,
-										ConversationActivity.REQUEST_ENCRYPT_MESSAGE);
+										ConversationActivity.REQUEST_CONTACT_KEY_PGP_XEP27);
 							}
 
 							@Override
@@ -1193,7 +1201,7 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 														  Contact contact) {
 								activity.runIntent(
 										pi,
-										ConversationActivity.REQUEST_ENCRYPT_MESSAGE);
+										ConversationActivity.REQUEST_CONTACT_KEY_PGP_OX);
 							}
 
 							@Override

--- a/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
@@ -227,8 +227,13 @@ public abstract class XmppActivity extends Activity {
 		}
 	}
 
+	/**
+	 * meant to check if the user has OpenKeychain installed.
+	 * TODO: PHILIP returns null sometimes even if OK is installed. Investigate.
+	 * @return
+	 */
 	public boolean hasPgp() {
-		return xmppConnectionService.getPgpEngine() != null;
+		return xmppConnectionService.getXep27PgpEngine() != null;
 	}
 
 	public void showInstallPgpDialog() {
@@ -492,7 +497,7 @@ public abstract class XmppActivity extends Activity {
 		if (account.getPgpId() == -1) {
 			choosePgpSignId(account);
 		} else {
-			xmppConnectionService.getPgpEngine().generateSignature(account, "", new UiCallback<Account>() {
+			xmppConnectionService.getXep27PgpEngine().generateSignature(account, "", new UiCallback<Account>() {
 
 				@Override
 				public void userInputRequried(PendingIntent pi,
@@ -522,8 +527,12 @@ public abstract class XmppActivity extends Activity {
 		}
 	}
 
+	protected void announceOxPgp(Account account, final Conversation conversation) {
+		// TODO: PHILIP
+	}
+
 	protected void choosePgpSignId(Account account) {
-		xmppConnectionService.getPgpEngine().chooseKey(account, new UiCallback<Account>() {
+		xmppConnectionService.getXep27PgpEngine().chooseKey(account, new UiCallback<Account>() {
 			@Override
 			public void success(Account account1) {
 			}

--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -585,12 +585,14 @@ public class MessageAdapter extends ArrayAdapter<Message> {
 			} else {
 				displayOpenableMessage(viewHolder, message);
 			}
-		} else if (message.getEncryption() == Message.ENCRYPTION_PGP) {
+		} else if (message.isAnyPgp()) {
 			if (activity.hasPgp()) {
 				if (account.getPgpDecryptionService().isRunning()) {
 					displayInfoMessage(viewHolder, activity.getString(R.string.message_decrypting), darkBackground);
-				} else {
+				} else if (message.getEncryption() == Message.ENCRYPTION_PGP) {
 					displayInfoMessage(viewHolder, activity.getString(R.string.pgp_message), darkBackground);
+				} else if (message.getEncryption() == Message.ENCRYPTION_PGP_OX) {
+					displayInfoMessage(viewHolder, activity.getString(R.string.ox_pgp_message), darkBackground);
 				}
 			} else {
 				displayInfoMessage(viewHolder,activity.getString(R.string.install_openkeychain),darkBackground);

--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -248,14 +248,14 @@ public class MessageAdapter extends ArrayAdapter<Message> {
 		viewHolder.messageBody.setTextIsSelectable(false);
 	}
 
-	private void displayDecryptionFailed(ViewHolder viewHolder, boolean darkBackground) {
+	private void displayDecryptionFailed(ViewHolder viewHolder, boolean darkBackground,
+										 int reasonStringId) {
 		if (viewHolder.download_button != null) {
 			viewHolder.download_button.setVisibility(View.GONE);
 		}
 		viewHolder.image.setVisibility(View.GONE);
 		viewHolder.messageBody.setVisibility(View.VISIBLE);
-		viewHolder.messageBody.setText(getContext().getString(
-				R.string.decryption_failed));
+		viewHolder.messageBody.setText(getContext().getString(reasonStringId));
 		viewHolder.messageBody.setTextColor(getMessageTextColor(darkBackground, false));
 		viewHolder.messageBody.setTypeface(null, Typeface.NORMAL);
 		viewHolder.messageBody.setTextIsSelectable(false);
@@ -585,7 +585,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
 			} else {
 				displayOpenableMessage(viewHolder, message);
 			}
-		} else if (message.isAnyPgp()) {
+		} else if (message.isStillEncryptedPgp()) {
 			if (activity.hasPgp()) {
 				if (account.getPgpDecryptionService().isRunning()) {
 					displayInfoMessage(viewHolder, activity.getString(R.string.message_decrypting), darkBackground);
@@ -607,8 +607,9 @@ public class MessageAdapter extends ArrayAdapter<Message> {
 						});
 				}
 			}
-		} else if (message.getEncryption() == Message.ENCRYPTION_DECRYPTION_FAILED) {
-			displayDecryptionFailed(viewHolder,darkBackground);
+		} else if (message.isDecryptionFail()) {
+			displayDecryptionFailed(viewHolder, darkBackground,
+					message.getDecryptionFailureReason());
 		} else {
 			if (GeoHelper.isGeoUri(message.getBody())) {
 				displayLocationMessage(viewHolder,message);

--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -170,7 +170,7 @@ public class UIHelper {
 				default:
 					return new Pair<>("",false);
 			}
-		} else if (message.getEncryption() == Message.ENCRYPTION_PGP) {
+		} else if (message.isAnyPgp()) {
 			return new Pair<>(context.getString(R.string.encrypted_message_received),true);
 		} else if (message.getType() == Message.TYPE_FILE || message.getType() == Message.TYPE_IMAGE) {
 			if (message.getStatus() == Message.STATUS_RECEIVED) {

--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -170,8 +170,10 @@ public class UIHelper {
 				default:
 					return new Pair<>("",false);
 			}
-		} else if (message.isAnyPgp()) {
-			return new Pair<>(context.getString(R.string.encrypted_message_received),true);
+		} else if (message.isStillEncryptedPgp()) {
+			return new Pair<>(context.getString(R.string.encrypted_message_received), true);
+		} else if (message.isDecryptionFail()) {
+			return new Pair<>(context.getString(message.getDecryptionFailureReason()), true);
 		} else if (message.getType() == Message.TYPE_FILE || message.getType() == Message.TYPE_IMAGE) {
 			if (message.getStatus() == Message.STATUS_RECEIVED) {
 				return new Pair<>(context.getString(R.string.received_x_file,

--- a/src/main/java/eu/siacs/conversations/xml/XmlReader.java
+++ b/src/main/java/eu/siacs/conversations/xml/XmlReader.java
@@ -20,6 +20,11 @@ public class XmlReader {
 	private InputStream is;
 
 	public XmlReader(WakeLock wakeLock) {
+		this();
+		this.wakeLock = wakeLock;
+	}
+
+	public XmlReader() {
 		this.parser = Xml.newPullParser();
 		try {
 			this.parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES,
@@ -27,7 +32,6 @@ public class XmlReader {
 		} catch (XmlPullParserException e) {
 			Log.d(Config.LOGTAG, "error setting namespace feature on parser");
 		}
-		this.wakeLock = wakeLock;
 	}
 
 	public void setInputStream(InputStream inputStream) throws IOException {
@@ -61,7 +65,7 @@ public class XmlReader {
 	}
 
 	public Tag readTag() throws XmlPullParserException, IOException {
-		if (wakeLock.isHeld()) {
+		if (wakeLock!=null && wakeLock.isHeld()) {
 			try {
 				wakeLock.release();
 			} catch (RuntimeException re) {
@@ -70,7 +74,9 @@ public class XmlReader {
 		try {
 			while (this.is != null
 					&& parser.next() != XmlPullParser.END_DOCUMENT) {
-				wakeLock.acquire();
+				if (wakeLock!=null) {
+					wakeLock.acquire();
+				}
 				if (parser.getEventType() == XmlPullParser.START_TAG) {
 					Tag tag = Tag.start(parser.getName());
 					for (int i = 0; i < parser.getAttributeCount(); ++i) {
@@ -90,7 +96,7 @@ public class XmlReader {
 					return tag;
 				}
 			}
-			if (wakeLock.isHeld()) {
+			if (wakeLock!=null && wakeLock.isHeld()) {
 				try {
 					wakeLock.release();
 				} catch (RuntimeException re) {

--- a/src/main/java/eu/siacs/conversations/xmpp/jid/Jid.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jid/Jid.java
@@ -180,6 +180,15 @@ public final class Jid {
 		}
 	}
 
+	/**
+	 * returns the bare Jid as a string by simply appending the localpart to the domainpart with a
+	 * "@"
+	 * @return
+	 */
+	public String toBareJidString() {
+		return localpart + "@" + domainpart;
+	}
+
 	public Jid toDomainJid() {
 		try {
 			return resourcepart.isEmpty() && localpart.isEmpty() ? this : fromString(getDomainpart());

--- a/src/main/res/menu/encryption_choices.xml
+++ b/src/main/res/menu/encryption_choices.xml
@@ -14,6 +14,9 @@
         <item
             android:id="@+id/encryption_choice_pgp"
             android:title="@string/encryption_choice_pgp"/>
+        <item
+            android:id="@+id/encryption_choice_ox_pgp"
+            android:title="@string/encryption_choice_ox_pgp"/>
     </group>
 
 </menu>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -84,7 +84,7 @@
 	<string name="send_otr_message">Send OTR encrypted message</string>
 	<string name="send_omemo_message">Send OMEMO encrypted message</string>
 	<string name="send_omemo_x509_message">Send v\\OMEMO encrypted message</string>
-	<string name="send_pgp_message">Send OpenPGP encrypted message</string>
+	<string name="send_pgp_message">Send XEP-0027 OpenPGP encrypted message</string>
 	<string name="send_ox_pgp_message">Send OpenPGP (OX) encrypted message</string>
 	<string name="your_nick_has_been_changed">Your nickname has been changed</string>
 	<string name="send_unencrypted">Send unencrypted</string>
@@ -122,7 +122,8 @@
 	<string name="pref_confirm_messages_summary">Let your contact know when you have received and read a message</string>
 	<string name="pref_ui_options">UI Options</string>
 	<string name="openpgp_error">OpenKeychain reported an error</string>
-	<string name="oxpgp_invalid_base64">Invalid Base64 encoding</string>
+	<string name="ox_pgp_invalid_base64">Invalid Base64 encoding</string>
+	<string name="ox_pgp_invalid_signature">This message has an invalid signature!</string>
 	<string name="error_decrypting_file">I/O Error decrypting file</string>
 	<string name="accept">Accept</string>
 	<string name="error">An error has occurred</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
 	<string name="pref_confirm_messages_summary">Let your contact know when you have received and read a message</string>
 	<string name="pref_ui_options">UI Options</string>
 	<string name="openpgp_error">OpenKeychain reported an error</string>
+	<string name="oxpgp_invalid_base64">Invalid Base64 encoding</string>
 	<string name="error_decrypting_file">I/O Error decrypting file</string>
 	<string name="accept">Accept</string>
 	<string name="error">An error has occurred</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -31,7 +31,8 @@
 	<string name="unread_conversations">unread Conversations</string>
 	<string name="sending">sending…</string>
 	<string name="message_decrypting">Decrypting message. Please wait…</string>
-	<string name="pgp_message">OpenPGP encrypted message</string>
+	<string name="pgp_message">XEP-0027 OpenPGP encrypted message</string>
+	<string name="ox_pgp_message">OpenPGP (OX) encrypted message</string>
 	<string name="nick_in_use">Nickname is already in use</string>
 	<string name="admin">Admin</string>
 	<string name="owner">Owner</string>
@@ -84,6 +85,7 @@
 	<string name="send_omemo_message">Send OMEMO encrypted message</string>
 	<string name="send_omemo_x509_message">Send v\\OMEMO encrypted message</string>
 	<string name="send_pgp_message">Send OpenPGP encrypted message</string>
+	<string name="send_ox_pgp_message">Send OpenPGP (OX) encrypted message</string>
 	<string name="your_nick_has_been_changed">Your nickname has been changed</string>
 	<string name="send_unencrypted">Send unencrypted</string>
 	<string name="decryption_failed">Decryption failed. Maybe you don’t have the proper private key.</string>
@@ -157,6 +159,7 @@
 	<string name="encryption_choice_unencrypted">Unencrypted</string>
 	<string name="encryption_choice_otr">OTR</string>
 	<string name="encryption_choice_pgp">OpenPGP</string>
+	<string name="encryption_choice_ox_pgp">OX (OpenPGP)</string>
 	<string name="encryption_choice_omemo">OMEMO</string>
 	<string name="mgmt_account_edit">Edit account</string>
 	<string name="mgmt_account_delete">Delete account</string>


### PR DESCRIPTION
This PR aims to add support for the new PGP XEP ([XEP-0374](https://xmpp.org/extensions/xep-0374.html)).

@dschuermann @valodim
Available as new option `OpenPgp (OX)` under the select encryption icon in a conversation.
Currently implemented:
- [x] Sending and receiving encryted and signed signcrypt messages in Base64 encoding.
- [x] Verification of signature of received message.

Key announcement currently piggy-backs on the announcement mechanism for XEP-0027.
Todo:
- [ ] Switch to public PEP node for public key announcement.
- [ ] Synchronization of private key using private PEP node.
- [ ] Mechanism to automatically add to existing/create new key with with `xmpp:user@example.org` as the userid.

Currently implemented features should allow messages to be exchanged between contacts, open to testing.
