### PR TITLE
PGP Retry decryption from message menu

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Message.java
+++ b/src/main/java/eu/siacs/conversations/entities/Message.java
@@ -449,6 +449,7 @@ public class Message extends AbstractEntity {
 						this.getTransferable() == null &&
 						message.getTransferable() == null &&
 						message.getEncryption() != Message.ENCRYPTION_PGP &&
+						message.getEncryption() != Message.ENCRYPTION_DECRYPTION_FAILED &&
 						this.getType() == message.getType() &&
 						//this.getStatus() == message.getStatus() &&
 						isStatusMergeable(this.getStatus(), message.getStatus()) &&

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -523,6 +523,7 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 			activity.getMenuInflater().inflate(R.menu.message_context, menu);
 			menu.setHeaderTitle(R.string.message_options);
 			MenuItem copyText = menu.findItem(R.id.copy_text);
+			MenuItem retryDecryption = menu.findItem(R.id.retry_decryption);
 			MenuItem correctMessage = menu.findItem(R.id.correct_message);
 			MenuItem shareWith = menu.findItem(R.id.share_with);
 			MenuItem sendAgain = menu.findItem(R.id.send_again);
@@ -534,6 +535,9 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 					&& !GeoHelper.isGeoUri(m.getBody())
 					&& m.treatAsDownloadable() != Message.Decision.MUST) {
 				copyText.setVisible(true);
+			}
+			if (m.getEncryption() == Message.ENCRYPTION_DECRYPTION_FAILED) {
+				retryDecryption.setVisible(true);
 			}
 			if (relevantForCorrection.getType() == Message.TYPE_TEXT
 					&& relevantForCorrection.isLastCorrectableMessage()) {
@@ -589,6 +593,9 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 				return true;
 			case R.id.cancel_transmission:
 				cancelTransmission(selectedMessage);
+				return true;
+			case R.id.retry_decryption:
+				retryDecryption(selectedMessage);
 				return true;
 			default:
 				return super.onContextItemSelected(item);
@@ -671,6 +678,12 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 		} else {
 			activity.xmppConnectionService.markMessage(message, Message.STATUS_SEND_FAILED);
 		}
+	}
+
+	private void retryDecryption(Message message) {
+		message.setEncryption(Message.ENCRYPTION_PGP);
+		activity.xmppConnectionService.updateConversationUi();
+		conversation.getAccount().getPgpDecryptionService().add(message);
 	}
 
 	protected void privateMessageWith(final Jid counterpart) {

--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -171,7 +171,9 @@ public class UIHelper {
 					return new Pair<>("",false);
 			}
 		} else if (message.getEncryption() == Message.ENCRYPTION_PGP) {
-			return new Pair<>(context.getString(R.string.encrypted_message_received),true);
+			return new Pair<>(context.getString(R.string.pgp_message),true);
+		} else if (message.getEncryption() == Message.ENCRYPTION_DECRYPTION_FAILED) {
+			return new Pair<>(context.getString(R.string.decryption_failed), true);
 		} else if (message.getType() == Message.TYPE_FILE || message.getType() == Message.TYPE_IMAGE) {
 			if (message.getStatus() == Message.STATUS_RECEIVED) {
 				return new Pair<>(context.getString(R.string.received_x_file,

--- a/src/main/res/menu/message_context.xml
+++ b/src/main/res/menu/message_context.xml
@@ -6,6 +6,10 @@
         android:title="@string/copy_text"
         android:visible="false"/>
     <item
+        android:id="@+id/retry_decryption"
+        android:title="Retry decryption"
+        android:visible="false"/>
+    <item
         android:id="@+id/correct_message"
         android:title="@string/correct_message"
         android:visible="false"/>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -97,7 +97,6 @@
 	<string name="contact_has_no_pgp_key">Conversations is unable to encrypt your messages because your contact is not announcing his or hers public key.\n\n<small>Please ask your contact to setup OpenPGP.</small></string>
 	<string name="no_pgp_keys">No OpenPGP Keys found</string>
 	<string name="contacts_have_no_pgp_keys">Conversations is unable to encrypt your messages because your contacts are not announcing their public key.\n\n<small>Please ask your contacts to setup OpenPGP.</small></string>
-	<string name="encrypted_message_received"><i>Encrypted message received. Touch to decrypt.</i></string>
 	<string name="pref_general">General</string>
 	<string name="pref_xmpp_resource">XMPP resource</string>
 	<string name="pref_xmpp_resource_summary">The name this client identifies itself with</string>


### PR DESCRIPTION
In the rare case OpenKeychain returns an error (e.g. the private key is not imported) the problem might be fixed by the user, so there should be a possibility to retry decryption, because otherwise the message is "lost".

This PR adds an entry "retry decryption" to the message menu to provide said possibility.
(It also does not show gibberish as a message preview in case of a failed decryption anymore and makes the message preview for PGP messages consistent with the text shown in the message bubble.)