### PR TITLE
Do not treat Right Alt key as a modifier for key combos

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -949,7 +949,7 @@ public class ConversationActivity extends XmppActivity
 				upKey = KeyEvent.KEYCODE_DPAD_UP;
 				downKey = KeyEvent.KEYCODE_DPAD_DOWN;
 		}
-		final boolean modifier = event.isCtrlPressed() || event.isAltPressed();
+		final boolean modifier = event.isCtrlPressed() || (event.getMetaState() & KeyEvent.META_ALT_LEFT_ON) != 0;
 		if (modifier && key == KeyEvent.KEYCODE_TAB && isConversationsOverviewHideable()) {
 			toggleConversationsOverview();
 			return true;


### PR DESCRIPTION
Conversations supports switching chats using Alt/Ctrl+<1-9> on keyboards that have these keys. However, it doesn't differentiate between Right and Left Alt keys. Depending on the keyboard layout, Right Alt is already reserved for key combos used for entering special characters (e. g. Right Alt + 2 = ² on a German keyboard). In these cases, the user unintentionally switches the active chat when trying to enter a special character.

This PR changes the behavior by limiting key combos with Alt keys to Left Alt.