### PR TITLE
Add contact through Gateway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	compile project(':libs:MemorizingTrustManager')
 	compile 'org.sufficientlysecure:openpgp-api:10.0'
 	compile 'com.soundcloud.android:android-crop:1.0.1@aar'
+	compile 'com.android.support:recyclerview-v7:+'
 	compile 'com.android.support:support-v13:23.2.0'
 	compile 'org.bouncycastle:bcprov-jdk15on:1.52'
 	compile 'org.bouncycastle:bcmail-jdk15on:1.52'
@@ -36,6 +37,7 @@ dependencies {
 	compile 'de.timroes.android:EnhancedListView:0.3.4'
 	compile 'me.leolin:ShortcutBadger:1.1.4@aar'
 	compile 'com.kyleduo.switchbutton:library:1.2.8'
+	compile 'org.solovyev.android.views:linear-layout-manager:0.5@aar'
 	compile 'org.whispersystems:axolotl-android:1.3.4'
 	compile 'com.makeramen:roundedimageview:2.2.0'
 	playstoreCompile 'com.google.android.gms:play-services-gcm:8.4.0'

--- a/src/main/java/eu/siacs/conversations/entities/Contact.java
+++ b/src/main/java/eu/siacs/conversations/entities/Contact.java
@@ -436,6 +436,16 @@ public class Contact implements ListItem, Blockable {
 				another.getDisplayName());
 	}
 
+	public boolean hasIdentity(String category, String type) {
+		for(Presence p : this.presences.getPresences().values()) {
+			if(p.getServiceDiscoveryResult().hasIdentity(category, type)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public Jid getServer() {
 		return getJid().toDomainJid();
 	}

--- a/src/main/java/eu/siacs/conversations/entities/Contact.java
+++ b/src/main/java/eu/siacs/conversations/entities/Contact.java
@@ -3,6 +3,7 @@ package eu.siacs.conversations.entities;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.util.Pair;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -11,6 +12,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.utils.UIHelper;
@@ -436,26 +438,36 @@ public class Contact implements ListItem, Blockable {
 				another.getDisplayName());
 	}
 
-	public boolean hasFeature(String feature) {
-		for(Presence p : this.presences.getPresences().values()) {
-			if(p.getServiceDiscoveryResult() != null &&
-			   p.getServiceDiscoveryResult().hasFeature(feature)) {
-				return true;
+	public Pair<Jid,Presence> getFeaturePresence(String feature) {
+		for(Map.Entry<String,Presence> e : this.presences.getPresences().entrySet()) {
+			if(e.getValue().getServiceDiscoveryResult() != null &&
+			   e.getValue().getServiceDiscoveryResult().hasFeature(feature)) {
+				try {
+					return new Pair<>(
+						Jid.fromParts(this.jid.getLocalpart(), this.jid.getDomainpart(), e.getKey()),
+						e.getValue()
+					);
+				} catch (final InvalidJidException ex) { /* Invalid, keep going */ }
 			}
 		}
 
-		return false;
+		return null;
 	}
 
-	public boolean hasIdentity(String category, String type) {
-		for(Presence p : this.presences.getPresences().values()) {
-			if(p.getServiceDiscoveryResult() != null &&
-			   p.getServiceDiscoveryResult().hasIdentity(category, type)) {
-				return true;
+	public Pair<Jid,Presence> getIdentityPresence(String category, String type) {
+		for(Map.Entry<String,Presence> e : this.presences.getPresences().entrySet()) {
+			if(e.getValue().getServiceDiscoveryResult() != null &&
+			   e.getValue().getServiceDiscoveryResult().hasIdentity(category, type)) {
+				try {
+					return new Pair<>(
+						Jid.fromParts(this.jid.getLocalpart(), this.jid.getDomainpart(), e.getKey()),
+						e.getValue()
+					);
+				} catch (final InvalidJidException ex) { /* Invalid, keep going */ }
 			}
 		}
 
-		return false;
+		return null;
 	}
 
 	public Jid getServer() {

--- a/src/main/java/eu/siacs/conversations/entities/Contact.java
+++ b/src/main/java/eu/siacs/conversations/entities/Contact.java
@@ -436,6 +436,17 @@ public class Contact implements ListItem, Blockable {
 				another.getDisplayName());
 	}
 
+	public boolean hasFeature(String feature) {
+		for(Presence p : this.presences.getPresences().values()) {
+			if(p.getServiceDiscoveryResult() != null &&
+			   p.getServiceDiscoveryResult().hasFeature(feature)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public boolean hasIdentity(String category, String type) {
 		for(Presence p : this.presences.getPresences().values()) {
 			if(p.getServiceDiscoveryResult() != null &&

--- a/src/main/java/eu/siacs/conversations/entities/Contact.java
+++ b/src/main/java/eu/siacs/conversations/entities/Contact.java
@@ -438,7 +438,8 @@ public class Contact implements ListItem, Blockable {
 
 	public boolean hasIdentity(String category, String type) {
 		for(Presence p : this.presences.getPresences().values()) {
-			if(p.getServiceDiscoveryResult().hasIdentity(category, type)) {
+			if(p.getServiceDiscoveryResult() != null &&
+			   p.getServiceDiscoveryResult().hasIdentity(category, type)) {
 				return true;
 			}
 		}

--- a/src/main/java/eu/siacs/conversations/entities/Presence.java
+++ b/src/main/java/eu/siacs/conversations/entities/Presence.java
@@ -88,6 +88,6 @@ public class Presence implements Comparable {
 	}
 
 	public ServiceDiscoveryResult getServiceDiscoveryResult() {
-		return disco;
+		return this.disco;
 	}
 }

--- a/src/main/java/eu/siacs/conversations/entities/Roster.java
+++ b/src/main/java/eu/siacs/conversations/entities/Roster.java
@@ -57,7 +57,7 @@ public class Roster {
 	public List<Contact> getWithFeature(final String feature) {
 		List<Contact> with = new ArrayList<>();
 		for(Contact c : this.contacts.values()) {
-			if(c.hasFeature(feature)) {
+			if(c.getFeaturePresence(feature) != null) {
 				with.add(c);
 			}
 		}
@@ -67,7 +67,7 @@ public class Roster {
 	public List<Contact> getWithIdentity(final String category, final String type) {
 		List<Contact> with = new ArrayList<>();
 		for(Contact c : this.contacts.values()) {
-			if(c.hasIdentity(category, type)) {
+			if(c.getIdentityPresence(category, type) != null) {
 				with.add(c);
 			}
 		}

--- a/src/main/java/eu/siacs/conversations/entities/Roster.java
+++ b/src/main/java/eu/siacs/conversations/entities/Roster.java
@@ -54,6 +54,16 @@ public class Roster {
 		}
 	}
 
+	public List<Contact> getWithIdentity(final String category, final String type) {
+		List<Contact> with = new ArrayList<>();
+		for(Contact c : this.contacts.values()) {
+			if(c.hasIdentity(category, type)) {
+				with.add(c);
+			}
+		}
+		return with;
+	}
+
 	public List<Contact> getWithSystemAccounts() {
 		List<Contact> with = getContacts();
 		for(Iterator<Contact> iterator = with.iterator(); iterator.hasNext();) {

--- a/src/main/java/eu/siacs/conversations/entities/Roster.java
+++ b/src/main/java/eu/siacs/conversations/entities/Roster.java
@@ -54,6 +54,16 @@ public class Roster {
 		}
 	}
 
+	public List<Contact> getWithFeature(final String feature) {
+		List<Contact> with = new ArrayList<>();
+		for(Contact c : this.contacts.values()) {
+			if(c.hasFeature(feature)) {
+				with.add(c);
+			}
+		}
+		return with;
+	}
+
 	public List<Contact> getWithIdentity(final String category, final String type) {
 		List<Contact> with = new ArrayList<>();
 		for(Contact c : this.contacts.values()) {

--- a/src/main/java/eu/siacs/conversations/entities/ServiceDiscoveryResult.java
+++ b/src/main/java/eu/siacs/conversations/entities/ServiceDiscoveryResult.java
@@ -228,6 +228,16 @@ public class ServiceDiscoveryResult {
 		return this.features;
 	}
 
+	public boolean hasFeature(String feature) {
+		for(String f : this.features) {
+			if(f.equals(feature)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public boolean hasIdentity(String category, String type) {
 		for(Identity id : this.getIdentities()) {
 			if((category == null || id.getCategory().equals(category)) &&

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -102,6 +102,7 @@ import eu.siacs.conversations.utils.Xmlns;
 import eu.siacs.conversations.xml.Element;
 import eu.siacs.conversations.xmpp.OnBindListener;
 import eu.siacs.conversations.xmpp.OnContactStatusChanged;
+import eu.siacs.conversations.xmpp.OnGatewayPromptResult;
 import eu.siacs.conversations.xmpp.OnIqPacketReceived;
 import eu.siacs.conversations.xmpp.OnKeyStatusUpdated;
 import eu.siacs.conversations.xmpp.OnMessageAcknowledged;
@@ -3253,6 +3254,23 @@ public class XmppConnectionService extends Service {
 			}
 			return result;
 		}
+	}
+
+	public void fetchGatewayPrompt(Account account, final Jid jid, final OnGatewayPromptResult callback) {
+		IqPacket request = new IqPacket(IqPacket.TYPE.GET);
+		request.setTo(jid);
+		request.query("jabber:iq:gateway");
+		sendIqPacket(account, request, new OnIqPacketReceived() {
+			@Override
+			public void onIqPacketReceived(Account account, IqPacket packet) {
+				if (packet.getType() == IqPacket.TYPE.RESULT) {
+					callback.onGatewayPromptResult(packet.query().findChildContent("prompt"), null);
+				} else {
+					Element error = packet.findChild("error");
+					callback.onGatewayPromptResult(null, error == null ? null : error.findChildContent("text"));
+				}
+			}
+		});
 	}
 
 	public void fetchCaps(Account account, final Jid jid, final Presence presence) {

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -102,7 +102,7 @@ import eu.siacs.conversations.utils.Xmlns;
 import eu.siacs.conversations.xml.Element;
 import eu.siacs.conversations.xmpp.OnBindListener;
 import eu.siacs.conversations.xmpp.OnContactStatusChanged;
-import eu.siacs.conversations.xmpp.OnGatewayPromptResult;
+import eu.siacs.conversations.xmpp.OnGatewayResult;
 import eu.siacs.conversations.xmpp.OnIqPacketReceived;
 import eu.siacs.conversations.xmpp.OnKeyStatusUpdated;
 import eu.siacs.conversations.xmpp.OnMessageAcknowledged;
@@ -3256,18 +3256,26 @@ public class XmppConnectionService extends Service {
 		}
 	}
 
-	public void fetchGatewayPrompt(Account account, final Jid jid, final OnGatewayPromptResult callback) {
-		IqPacket request = new IqPacket(IqPacket.TYPE.GET);
+	public void fetchFromGateway(Account account, final Jid jid, final String input, final OnGatewayResult callback) {
+		IqPacket request = new IqPacket(input == null ? IqPacket.TYPE.GET : IqPacket.TYPE.SET);
 		request.setTo(jid);
-		request.query("jabber:iq:gateway");
+		Element query = request.query("jabber:iq:gateway");
+		if(input != null) {
+			Element prompt = query.addChild("prompt");
+			prompt.setContent(input);
+		}
+
 		sendIqPacket(account, request, new OnIqPacketReceived() {
 			@Override
 			public void onIqPacketReceived(Account account, IqPacket packet) {
 				if (packet.getType() == IqPacket.TYPE.RESULT) {
-					callback.onGatewayPromptResult(packet.query().findChildContent("prompt"), null);
+					callback.onGatewayResult(
+						packet.query().findChildContent(input == null ? "prompt" : "jid"),
+						null
+					);
 				} else {
 					Element error = packet.findChild("error");
-					callback.onGatewayPromptResult(null, error == null ? null : error.findChildContent("text"));
+					callback.onGatewayResult(null, error == null ? null : error.findChildContent("text"));
 				}
 			}
 		});

--- a/src/main/java/eu/siacs/conversations/ui/EnterJidDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/EnterJidDialog.java
@@ -124,14 +124,12 @@ public class EnterJidDialog {
 				}
 			} else {
 				viewHolder.useButton(this.gateways.get(i-1).first.getDisplayName());
-
-				for(Presence p : this.gateways.get(i-1).first.getPresences().getPresences().values()) {
-					if(p.getServiceDiscoveryResult() != null) {
-						for(ServiceDiscoveryResult.Identity id : p.getServiceDiscoveryResult().getIdentities()) {
-							if(id.getCategory().equals("gateway")) {
-								viewHolder.useButton(id.getType());
-								break;
-							}
+				Pair<Jid,Presence> p = this.gateways.get(i-1).first.getIdentityPresence("gateway", null);
+				if(p != null) {
+					for(ServiceDiscoveryResult.Identity id : p.second.getServiceDiscoveryResult().getIdentities()) {
+						if(id.getCategory().equals("gateway")) {
+							viewHolder.useButton(id.getType());
+							break;
 						}
 					}
 				}

--- a/src/main/java/eu/siacs/conversations/ui/EnterJidDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/EnterJidDialog.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.DialogInterface.OnClickListener;
 import android.content.DialogInterface;
 import android.support.v7.widget.RecyclerView;
+import android.text.InputType;
 import android.util.Log;
 import android.util.Pair;
 import android.view.LayoutInflater;
@@ -147,9 +148,11 @@ public class EnterJidDialog {
 
 			if(i == 0) {
 				jid.setThreshold(1);
+				jid.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS | InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE);
 				jid.setHint(R.string.account_settings_example_jabber_id);
 			} else {
 				jid.setThreshold(999999); // do not autocomplete
+				jid.setInputType(InputType.TYPE_CLASS_TEXT);
 				jid.setHint(this.gateways.get(i-1).second);
 			}
 

--- a/src/main/java/eu/siacs/conversations/ui/EnterJidDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/EnterJidDialog.java
@@ -2,18 +2,34 @@ package eu.siacs.conversations.ui;
 
 import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface.OnClickListener;
+import android.content.DialogInterface;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.Spinner;
 import android.widget.TextView;
-
+import android.widget.ToggleButton;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.TreeSet;
+import org.solovyev.android.views.llm.LinearLayoutManager;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
+import eu.siacs.conversations.entities.Account;
+import eu.siacs.conversations.entities.Contact;
+import eu.siacs.conversations.entities.Presence;
+import eu.siacs.conversations.entities.ServiceDiscoveryResult;
 import eu.siacs.conversations.ui.adapter.KnownHostsAdapter;
+import eu.siacs.conversations.xmpp.OnGatewayPromptResult;
 import eu.siacs.conversations.xmpp.jid.InvalidJidException;
 import eu.siacs.conversations.xmpp.jid.Jid;
 
@@ -34,23 +50,144 @@ public class EnterJidDialog {
 		}
 	}
 
+	protected class GatewayListAdapter extends RecyclerView.Adapter<GatewayListAdapter.ViewHolder> {
+		protected class ViewHolder extends RecyclerView.ViewHolder {
+			protected TextView label;
+			protected ToggleButton button;
+			protected int index;
+
+			public ViewHolder(View view, int i) {
+				super(view);
+				this.label = (TextView) view.findViewById(R.id.label);
+				this.button = (ToggleButton) view.findViewById(R.id.button);
+				setIndex(i);
+				button.setOnClickListener(new View.OnClickListener() {
+					@Override
+					public void onClick(View v) {
+						button.setChecked(true); // Force visual not to flap to unchecked
+						setSelected(index);
+					}
+				});
+			}
+
+			public void setIndex(int i) {
+				this.index = i;
+				button.setChecked(selected == i);
+			}
+
+			public void setText(int res) {
+				label.setText(res);
+				button.setVisibility(View.GONE);
+				label.setVisibility(View.VISIBLE);
+			}
+
+			public void useButton(int res) {
+				button.setText(res);
+				button.setTextOff(button.getText());
+				button.setTextOn(button.getText());
+				label.setVisibility(View.GONE);
+				button.setVisibility(View.VISIBLE);
+			}
+
+			public void useButton(String txt) {
+				button.setTextOff(txt);
+				button.setTextOn(txt);
+				button.setChecked(selected == this.index);
+				label.setVisibility(View.GONE);
+				button.setVisibility(View.VISIBLE);
+			}
+		}
+
+		protected List<Pair<Contact,String>> gateways;
+		protected int selected;
+
+		public GatewayListAdapter() {
+			this.gateways = new ArrayList<>();
+			this.selected = 0;
+		}
+
+		@Override
+		public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
+			View view = LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.enter_jid_dialog_gateway_list_item, null);
+			return new ViewHolder(view, i);
+		}
+
+		@Override
+		public void onBindViewHolder(ViewHolder viewHolder, int i) {
+			viewHolder.setIndex(i);
+
+			if(i == 0) {
+				if(getItemCount() < 2) {
+					viewHolder.setText(R.string.account_settings_jabber_id);
+				} else {
+					viewHolder.useButton(R.string.account_settings_jabber_id);
+				}
+			} else {
+				viewHolder.useButton(this.gateways.get(i-1).first.getDisplayName());
+
+				for(Presence p : this.gateways.get(i-1).first.getPresences().getPresences().values()) {
+					if(p.getServiceDiscoveryResult() != null) {
+						for(ServiceDiscoveryResult.Identity id : p.getServiceDiscoveryResult().getIdentities()) {
+							if(id.getCategory().equals("gateway")) {
+								viewHolder.useButton(id.getType());
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		@Override
+		public int getItemCount() {
+			return this.gateways.size() + 1;
+		}
+
+		public void setSelected(int i) {
+			int old = this.selected;
+			this.selected = i;
+
+			if(i == 0) {
+				jid.setThreshold(1);
+				jid.setHint(R.string.account_settings_example_jabber_id);
+			} else {
+				jid.setThreshold(999999); // do not autocomplete
+				jid.setHint(this.gateways.get(i-1).second);
+			}
+
+			notifyItemChanged(old);
+			notifyItemChanged(i);
+		}
+
+		public void clear() {
+			this.gateways.clear();
+			notifyDataSetChanged();
+			setSelected(0);
+		}
+
+		public void add(Contact gateway, String prompt) {
+			this.gateways.add(new Pair<>(gateway, prompt));
+			notifyDataSetChanged();
+		}
+	}
+
 	protected final AlertDialog dialog;
 	protected View.OnClickListener dialogOnClick;
 	protected OnEnterJidDialogPositiveListener listener = null;
+	protected final Spinner spinner;
+	protected final AutoCompleteTextView jid;
 
 	public EnterJidDialog(
-		final Context context, List<String> knownHosts, final List<String> activatedAccounts,
+		final XmppActivity context, List<String> knownHosts, final List<String> activatedAccounts,
 		final String title, final String positiveButton,
 		final String prefilledJid, final String account, boolean allowEditJid
 	) {
 		AlertDialog.Builder builder = new AlertDialog.Builder(context);
 		builder.setTitle(title);
 		View dialogView = LayoutInflater.from(context).inflate(R.layout.enter_jid_dialog, null);
-		final TextView jabberIdDesc = (TextView) dialogView.findViewById(R.id.jabber_id);
-		jabberIdDesc.setText(R.string.account_settings_jabber_id);
-		final Spinner spinner = (Spinner) dialogView.findViewById(R.id.account);
-		final AutoCompleteTextView jid = (AutoCompleteTextView) dialogView.findViewById(R.id.jid);
-		jid.setAdapter(new KnownHostsAdapter(context, R.layout.simple_list_item, knownHosts));
+		this.spinner = (Spinner) dialogView.findViewById(R.id.account);
+		jid = (AutoCompleteTextView) dialogView.findViewById(R.id.jid);
+		jid.setAdapter(new KnownHostsAdapter(context,R.layout.simple_list_item, knownHosts));
 		if (prefilledJid != null) {
 			jid.append(prefilledJid);
 			if (!allowEditJid) {
@@ -61,7 +198,9 @@ public class EnterJidDialog {
 			}
 		}
 
-		jid.setHint(R.string.account_settings_example_jabber_id);
+		final RecyclerView gatewayList = (RecyclerView) dialogView.findViewById(R.id.gateway_list);
+		gatewayList.setLayoutManager(new LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false));
+		gatewayList.setAdapter(new GatewayListAdapter());
 
 		if (account == null) {
 			StartConversationActivity.populateAccountSpinner(context, activatedAccounts, spinner);
@@ -74,6 +213,40 @@ public class EnterJidDialog {
 			spinner.setAdapter(adapter);
 		}
 
+		spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+			@Override
+			public void onItemSelected(AdapterView spinner, View view, int position, long id) {
+				final Jid accountJid = getAccountJid();
+				if(context.xmppConnectionService != null && accountJid != null) {
+					((GatewayListAdapter) gatewayList.getAdapter()).clear();
+
+					final Account account = context.xmppConnectionService.findAccountByJid(accountJid);
+					TreeSet<Contact> gateways = new TreeSet<>(account.getRoster().getWithIdentity("gateway", null));
+					gateways.addAll(account.getRoster().getWithFeature("jabber:iq:gateway"));
+
+					for(final Contact gateway : gateways) {
+						context.xmppConnectionService.fetchGatewayPrompt(account, gateway.getJid(), new OnGatewayPromptResult() {
+							@Override
+							public void onGatewayPromptResult(final String prompt, String errorMessage) {
+								if (prompt != null) {
+									context.runOnUiThread(new Runnable() {
+										public void run() {
+											((GatewayListAdapter) gatewayList.getAdapter()).add(gateway, prompt);
+										}
+									});
+								}
+							}
+						});
+					}
+				}
+			}
+
+			@Override
+			public void onNothingSelected(AdapterView spinner) {
+				((GatewayListAdapter) gatewayList.getAdapter()).clear();
+			}
+		});
+
 		builder.setView(dialogView);
 		builder.setNegativeButton(R.string.cancel, null);
 		builder.setPositiveButton(positiveButton, null);
@@ -82,19 +255,10 @@ public class EnterJidDialog {
 		this.dialogOnClick = new View.OnClickListener() {
 			@Override
 			public void onClick(final View v) {
-				final Jid accountJid;
 				if (!spinner.isEnabled() && account == null) {
 					return;
 				}
-				try {
-					if (Config.DOMAIN_LOCK != null) {
-						accountJid = Jid.fromParts((String) spinner.getSelectedItem(), Config.DOMAIN_LOCK, null);
-					} else {
-						accountJid = Jid.fromString((String) spinner.getSelectedItem());
-					}
-				} catch (final InvalidJidException e) {
-					return;
-				}
+				final Jid accountJid = getAccountJid();
 				final Jid contactJid;
 				try {
 					contactJid = Jid.fromString(jid.getText().toString());
@@ -114,6 +278,18 @@ public class EnterJidDialog {
 				}
 			}
 		};
+	}
+
+	protected Jid getAccountJid() {
+		try {
+			if (Config.DOMAIN_LOCK != null) {
+				return Jid.fromParts((String) spinner.getSelectedItem(), Config.DOMAIN_LOCK, null);
+			} else {
+				return Jid.fromString((String) spinner.getSelectedItem());
+			}
+		} catch (final InvalidJidException e) {
+			return null;
+		}
 	}
 
 	public void setOnEnterJidDialogPositiveListener(OnEnterJidDialogPositiveListener listener) {

--- a/src/main/java/eu/siacs/conversations/xmpp/OnGatewayPromptResult.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/OnGatewayPromptResult.java
@@ -1,0 +1,7 @@
+package eu.siacs.conversations.xmpp;
+
+public interface OnGatewayPromptResult {
+	// if prompt is null, there was an error
+	// errorText may or may not be set
+	public void onGatewayPromptResult(String prompt, String errorText);
+}

--- a/src/main/java/eu/siacs/conversations/xmpp/OnGatewayPromptResult.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/OnGatewayPromptResult.java
@@ -1,7 +1,0 @@
-package eu.siacs.conversations.xmpp;
-
-public interface OnGatewayPromptResult {
-	// if prompt is null, there was an error
-	// errorText may or may not be set
-	public void onGatewayPromptResult(String prompt, String errorText);
-}

--- a/src/main/java/eu/siacs/conversations/xmpp/OnGatewayResult.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/OnGatewayResult.java
@@ -1,0 +1,7 @@
+package eu.siacs.conversations.xmpp;
+
+public interface OnGatewayResult {
+	// if result is null, there was an error
+	// errorText may or may not be set
+	public void onGatewayResult(String result, String errorText);
+}

--- a/src/main/java/eu/siacs/conversations/xmpp/jid/Jid.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jid/Jid.java
@@ -37,6 +37,21 @@ public final class Jid {
 		return resourcepart;
 	}
 
+	// XEP-0106
+	public static String escapeLocalpart(String s) {
+		return s.
+			replace("\\", "\\5c").
+			replace("@", "\\40").
+			replace(">", "\\3e").
+			replace("<", "\\3c").
+			replace(":", "\\3a").
+			replace("/", "\\2f").
+			replace("\'", "\\27").
+			replace("&", "\\26").
+			replace("\"", "\\22").
+			replace(" ", "\\20");
+	}
+
 	public static Jid fromSessionID(final SessionID id) throws InvalidJidException{
 		if (id.getUserID().isEmpty()) {
 			return Jid.fromString(id.getAccountID());
@@ -221,6 +236,6 @@ public final class Jid {
 	}
 
 	public boolean isDomainJid() {
-		return !this.hasLocalpart();
+		return !this.hasLocalpart() && this.resourcepart.isEmpty();
 	}
 }

--- a/src/main/res/layout/enter_jid_dialog.xml
+++ b/src/main/res/layout/enter_jid_dialog.xml
@@ -19,16 +19,13 @@
     <Spinner
         android:id="@+id/account"
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
 
-    <TextView
-        android:id="@+id/jabber_id"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/gateway_list"
         android:layout_marginTop="8dp"
-        android:text="@string/account_settings_jabber_id"
-        android:textColor="?attr/color_text_primary"
-        android:textSize="?attr/TextSizeBody"/>
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content" />
 
     <AutoCompleteTextView
         android:id="@+id/jid"
@@ -39,5 +36,4 @@
         android:textColor="?attr/color_text_primary"
         android:textColorHint="?attr/color_text_secondary"
         android:textSize="?attr/TextSizeBody" />
-
 </LinearLayout>

--- a/src/main/res/layout/enter_jid_dialog_gateway_list_item.xml
+++ b/src/main/res/layout/enter_jid_dialog_gateway_list_item.xml
@@ -1,0 +1,23 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              android:paddingRight="5dp">
+
+    <TextView
+        android:id="@+id/label"
+        android:gravity="left"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/color_text_primary"
+        android:textSize="?attr/TextSizeBody" />
+
+    <ToggleButton
+        android:id="@+id/button"
+        android:gravity="center"
+        android:visibility="gone"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/color_text_primary"
+        android:textSize="?attr/TextSizeBody" />
+</LinearLayout>


### PR DESCRIPTION
This provide a UI for users who have gateways in their roster to use for adding contacts without thinking about the details of how to translate the legacy id into a JID for use with their particular gateway.  So long as the gateway is in their roster, they are presented with an option during contact add to use the gateway instead, and then the correct translation is done by the gateway so that the user does not need to know the exact format.

Closes #1601 