### PR TITLE
Use the last message in the content text instead of the first.

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -376,7 +376,7 @@ public class NotificationService {
 			builder.setStyle(messagingStyle);
 		} else {
 			builder.setStyle(new NotificationCompat.BigTextStyle().bigText(getMergedBodies(messages)));
-			builder.setContentText(UIHelper.getMessagePreview(mXmppConnectionService, messages.get(0)).first);
+			builder.setContentText(UIHelper.getMessagePreview(mXmppConnectionService, messages.get((messages.size()-1))).first);
 		}
 	}
 


### PR DESCRIPTION
This fixes the issue where the first message in the notification was sent to pebble
(and possibly to other wear devices) for every update in the conversation, as
reported in #1249.

This is the same patch propoed in https://github.com/siacs/Conversations/issues/1249#issuecomment-245878335