### PR TITLE
SASL ANONYMOUS (no UI)

### DIFF
--- a/src/main/java/eu/siacs/conversations/crypto/sasl/Anonymous.java
+++ b/src/main/java/eu/siacs/conversations/crypto/sasl/Anonymous.java
@@ -1,0 +1,28 @@
+package eu.siacs.conversations.crypto.sasl;
+
+import java.security.SecureRandom;
+
+import eu.siacs.conversations.entities.Account;
+import eu.siacs.conversations.xml.TagWriter;
+
+public class Anonymous extends SaslMechanism {
+
+	public Anonymous(TagWriter tagWriter, Account account, SecureRandom rng) {
+		super(tagWriter, account, rng);
+	}
+
+	@Override
+	public int getPriority() {
+		return 0;
+	}
+
+	@Override
+	public String getMechanism() {
+		return "ANONYMOUS";
+	}
+
+	@Override
+	public String getClientFirstMessage() {
+		return "";
+	}
+}

--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -981,7 +981,7 @@ public class XmppConnection implements Runnable {
 					final Element jid = bind.findChild("jid");
 					if (jid != null && jid.getContent() != null) {
 						try {
-							account.setResource(Jid.fromString(jid.getContent()).getResourcepart());
+							account.setJid(Jid.fromString(jid.getContent()));
 							if (streamFeatures.hasChild("session")
 									&& !streamFeatures.findChild("session").hasChild("optional")) {
 								sendStartSession();

--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -55,6 +55,7 @@ import javax.net.ssl.X509TrustManager;
 import de.duenndns.ssl.MemorizingTrustManager;
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.crypto.XmppDomainVerifier;
+import eu.siacs.conversations.crypto.sasl.Anonymous;
 import eu.siacs.conversations.crypto.sasl.DigestMd5;
 import eu.siacs.conversations.crypto.sasl.External;
 import eu.siacs.conversations.crypto.sasl.Plain;
@@ -841,6 +842,8 @@ public class XmppConnection implements Runnable {
 			saslMechanism = new Plain(tagWriter, account);
 		} else if (mechanisms.contains("DIGEST-MD5")) {
 			saslMechanism = new DigestMd5(tagWriter, account, mXmppConnectionService.getRNG());
+		} else if (mechanisms.contains("ANONYMOUS")) {
+			saslMechanism = new Anonymous(tagWriter, account, mXmppConnectionService.getRNG());
 		}
 		if (saslMechanism != null) {
 			final JSONObject keys = account.getKeys();


### PR DESCRIPTION
I haven't tested the second commit that fixes bind to use the JID returned by the server because I don't have a machine with all the dependencies to build Conversations right now; the actual ANONYMOUS mechanism works fine though.

I'll try to get an Android dev environment setup and test the second commit too.