### PR TITLE
Dismiss the notification when replying from a wear notification [needs review!]

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -297,11 +297,11 @@ public class NotificationService {
 					modifyForTextOnly(mBuilder, messages);
 				}
 				RemoteInput remoteInput = new RemoteInput.Builder("text_reply").setLabel(UIHelper.getMessageHint(mXmppConnectionService, conversation)).build();
-				NotificationCompat.Action action = new NotificationCompat.Action.Builder(R.drawable.ic_send_text_offline, "Reply", createReplyIntent(conversation)).addRemoteInput(remoteInput).build();
+				NotificationCompat.Action replyAction = new NotificationCompat.Action.Builder(R.drawable.ic_send_text_offline, "Reply", createReplyIntent(conversation, false)).addRemoteInput(remoteInput).build();
+				NotificationCompat.Action wearReplyAction = new NotificationCompat.Action.Builder(R.drawable.ic_send_text_offline, "Reply", createReplyIntent(conversation, true)).addRemoteInput(remoteInput).build();
+				mBuilder.extend(new NotificationCompat.WearableExtender().addAction(wearReplyAction));
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-					mBuilder.addAction(action);
-				} else {
-					mBuilder.extend(new NotificationCompat.WearableExtender().addAction(action));
+					mBuilder.addAction(replyAction);
 				}
 				if ((message = getFirstDownloadableMessage(messages)) != null) {
 					mBuilder.addAction(
@@ -474,11 +474,13 @@ public class NotificationService {
 		return PendingIntent.getService(mXmppConnectionService, 0, intent, 0);
 	}
 
-	private PendingIntent createReplyIntent(Conversation conversation) {
+	private PendingIntent createReplyIntent(Conversation conversation, boolean dismissAfterReply) {
 		final Intent intent = new Intent(mXmppConnectionService, XmppConnectionService.class);
 		intent.setAction(XmppConnectionService.ACTION_REPLY_TO_CONVERSATION);
 		intent.putExtra("uuid",conversation.getUuid());
-		return PendingIntent.getService(mXmppConnectionService, conversation.getUuid().hashCode() % 402361, intent, 0);
+		intent.putExtra("dismiss_notification",dismissAfterReply);
+		int id =  conversation.getUuid().hashCode() % (dismissAfterReply ? 402359 : 426583);
+		return PendingIntent.getService(mXmppConnectionService, id, intent, 0);
 	}
 
 	private PendingIntent createDisableForeground() {

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -575,7 +575,7 @@ public class XmppConnectionService extends Service {
 					if (remoteInput != null && c != null) {
 						final CharSequence body = remoteInput.getCharSequence("text_reply");
 						if (body != null && body.length() > 0) {
-							directReply(c, body.toString());
+							directReply(c, body.toString(),intent.getBooleanExtra("dismiss_notification",false));
 						}
 					}
 					break;
@@ -708,7 +708,7 @@ public class XmppConnectionService extends Service {
 		}
 	}
 
-	private void directReply(Conversation conversation, String body) {
+	private void directReply(Conversation conversation, String body, final boolean dismissAfterReply) {
 		Message message = new Message(conversation,body,conversation.getNextEncryption());
 		message.markUnread();
 		if (message.getEncryption() == Message.ENCRYPTION_PGP) {
@@ -717,7 +717,11 @@ public class XmppConnectionService extends Service {
 				public void success(Message message) {
 					message.setEncryption(Message.ENCRYPTION_DECRYPTED);
 					sendMessage(message);
-					mNotificationService.pushFromDirectReply(message);
+					if (dismissAfterReply) {
+						markRead(message.getConversation(),true);
+					} else {
+						mNotificationService.pushFromDirectReply(message);
+					}
 				}
 
 				@Override
@@ -732,7 +736,11 @@ public class XmppConnectionService extends Service {
 			});
 		} else {
 			sendMessage(message);
-			mNotificationService.pushFromDirectReply(message);
+			if (dismissAfterReply) {
+				markRead(conversation,true);
+			} else {
+				mNotificationService.pushFromDirectReply(message);
+			}
 		}
 	}
 


### PR DESCRIPTION
The dismissal is made through an additional extra to keep the changes in XmppConnectionService at a minimum and avoid duplicate code

What I don't particularly like about this solution:
- ~~having two separate actions in the pendingintent in NotificationService, but apparently it's needed (see: http://stackoverflow.com/questions/3127957/why-the-pendingintent-doesnt-send-back-my-custom-extras-setup-for-the-intent)~~ fixed as of 3c9de13
- ~~I didn't want to change conversation and the boolean to final, which would have been needed for the GPG encryption~~ fixed as of 3c9de13