### PR TITLE
Added Background Color change on Conversation Activity

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
@@ -135,6 +135,7 @@ public class ContactDetailsActivity extends OmemoActivity implements OnAccountUp
 
 	private OnClickListener onBadgeClick = new OnClickListener() {
 
+		//When contact's image is clicked
 		@Override
 		public void onClick(View v) {
 			Uri systemAccount = contact.getSystemAccount();

--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -97,6 +97,8 @@ public class ConversationActivity extends XmppActivity
 	private static final String STATE_FIRST_VISIBLE = "first_visible";
 	private static final String STATE_OFFSET_FROM_TOP = "offset_from_top";
 
+	private static String background_color = "grey";
+
 	private String mOpenConversation = null;
 	private boolean mPanelOpen = true;
 	private Pair<Integer,Integer> mScrollPosition = null;
@@ -395,6 +397,7 @@ public class ConversationActivity extends XmppActivity
 		final MenuItem menuInviteContact = menu.findItem(R.id.action_invite);
 		final MenuItem menuMute = menu.findItem(R.id.action_mute);
 		final MenuItem menuUnmute = menu.findItem(R.id.action_unmute);
+		final MenuItem menuBackground = menu.findItem(R.id.action_change_background_color);
 
 		if (isConversationsOverviewVisable() && isConversationsOverviewHideable()) {
 			menuArchive.setVisible(false);
@@ -406,6 +409,8 @@ public class ConversationActivity extends XmppActivity
 			menuClearHistory.setVisible(false);
 			menuMute.setVisible(false);
 			menuUnmute.setVisible(false);
+			menuBackground.setVisible(false);
+
 		} else {
 			menuAdd.setVisible(!isConversationsOverviewHideable());
 			if (this.getSelectedConversation() != null) {
@@ -712,7 +717,7 @@ public class ConversationActivity extends XmppActivity
 					BlockContactDialog.show(this, xmppConnectionService, getSelectedConversation());
 					break;
 				case R.id.action_change_background_color:
-					//TODO
+					changeBackgroundColorDialog(getSelectedConversation());
 					break;
 				default:
 					break;
@@ -963,9 +968,54 @@ public class ConversationActivity extends XmppActivity
 		builder.create().show();
 	}
 
+	//Shows a dialog that allows to change conversations background
 	protected void changeBackgroundColorDialog(final Conversation conversation)
 	{
-		//TODO
+		View menuItemView = findViewById(R.id.action_security);
+		if (menuItemView == null) {
+			return;
+		}
+		PopupMenu popup = new PopupMenu(this, menuItemView);
+		popup.inflate(R.menu.background_color_choice);
+		MenuItem grey = popup.getMenu().findItem(R.id.background_color_grey);
+		MenuItem red = popup.getMenu().findItem(R.id.background_color_red);
+		MenuItem blue = popup.getMenu().findItem(R.id.background_color_blue);
+		grey.setVisible(true);
+		red.setVisible(true);
+		blue.setVisible(true);
+
+		popup.setOnMenuItemClickListener(new OnMenuItemClickListener() {
+
+			@Override
+			public boolean onMenuItemClick(MenuItem item) {
+				switch (item.getItemId()) {
+					case R.id.background_color_grey:
+						setBackgroundColor("grey");
+						item.setChecked(true);
+						break;
+					case R.id.background_color_red:
+						setBackgroundColor("red");
+						item.setChecked(true);
+						break;
+					case R.id.background_color_blue:
+						setBackgroundColor("blue");
+						item.setChecked(true);
+						break;
+					default:
+						setBackgroundColor("grey");
+						break;
+				}
+				invalidateOptionsMenu();
+
+				mTheme = findTheme();
+				setTheme(mTheme);
+				setContentView(R.layout.fragment_conversations_overview);
+				recreate();
+				refreshUi();
+				return true;
+			}
+		});
+		popup.show();
 		return;
 	}
 
@@ -1775,6 +1825,66 @@ public class ConversationActivity extends XmppActivity
 		if (mConversationFragment != null) {
 			mConversationFragment.setMessagesLoaded();
 			mConversationFragment.updateMessages();
+		}
+	}
+
+	public String getBackgroundColor(){ return this.background_color;};
+
+	public void setBackgroundColor(String color)
+	{
+		this.background_color = color;
+	}
+
+	protected int findTheme() {
+		Boolean dark   = getPreferences().getString("theme", "light").equals("dark");
+		Boolean larger = getPreferences().getBoolean("use_larger_font", false);
+
+		if(dark) {
+			if(larger)
+			{
+				if(background_color == "grey")
+					return R.style.ConversationsTheme_Dark_LargerText_GreyBackgroundColor;
+				else if(background_color == "red")
+					return R.style.ConversationsTheme_Dark_LargerText_RedBackgroundColor;
+				else if(background_color == "blue")
+					return R.style.ConversationsTheme_Dark_LargerText_BlueBackgroundColor;
+				else
+					return R.style.ConversationsTheme_Dark_LargerText_GreyBackgroundColor;
+			}
+			else
+			{
+				if(background_color == "grey")
+					return R.style.ConversationsTheme_Dark_GreyBackgroundColor;
+				else if(background_color == "red")
+					return R.style.ConversationsTheme_Dark_RedBackgroundColor;
+				else if(background_color == "blue")
+					return R.style.ConversationsTheme_Dark_BlueBackgroundColor;
+				else
+					return R.style.ConversationsTheme_Dark_GreyBackgroundColor;
+			}
+		} else {
+			if (larger)
+			{
+				if(background_color == "grey")
+					return R.style.ConversationsTheme_LargerText_GreyBackgroundColor;
+				else if(background_color == "red")
+					return R.style.ConversationsTheme_LargerText_RedBackgroundColor;
+				else if(background_color == "blue")
+					return R.style.ConversationsTheme_LargerText_BlueBackgroundColor;
+				else
+					return R.style.ConversationsTheme_LargerText_GreyBackgroundColor;
+			}
+			else
+			{
+				if(background_color == "grey")
+					return R.style.ConversationsTheme_GreyBackgroundColor;
+				else if(background_color == "red")
+					return R.style.ConversationsTheme_RedBackgroundColor;
+				else if(background_color == "blue")
+					return R.style.ConversationsTheme_BlueBackgroundColor;
+				else
+					return R.style.ConversationsTheme_GreyBackgroundColor;
+			}
 		}
 	}
 }

--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -663,6 +663,7 @@ public class ConversationActivity extends XmppActivity
 		}
 	}
 
+	//When one of the buttons in the top of the conversation screen is clicked
 	@Override
 	public boolean onOptionsItemSelected(final MenuItem item) {
 		if (item.getItemId() == android.R.id.home) {
@@ -709,6 +710,9 @@ public class ConversationActivity extends XmppActivity
 					break;
 				case R.id.action_unblock:
 					BlockContactDialog.show(this, xmppConnectionService, getSelectedConversation());
+					break;
+				case R.id.action_change_background_color:
+					//TODO
 					break;
 				default:
 					break;
@@ -847,11 +851,11 @@ public class ConversationActivity extends XmppActivity
 	}
 
 	protected void selectEncryptionDialog(final Conversation conversation) {
-		View menuItemView = findViewById(R.id.action_security);
+		View menuItemView = findViewById(R.id.action_security); //Gets the xml menu from resources
 		if (menuItemView == null) {
 			return;
 		}
-		PopupMenu popup = new PopupMenu(this, menuItemView);
+		PopupMenu popup = new PopupMenu(this, menuItemView); //MenuItemView is where the popup will appear from
 		final ConversationFragment fragment = (ConversationFragment) getFragmentManager()
 				.findFragmentByTag("conversation");
 		if (fragment != null) {
@@ -902,6 +906,7 @@ public class ConversationActivity extends XmppActivity
 			MenuItem none = popup.getMenu().findItem(R.id.encryption_choice_none);
 			MenuItem pgp = popup.getMenu().findItem(R.id.encryption_choice_pgp);
 			MenuItem axolotl = popup.getMenu().findItem(R.id.encryption_choice_axolotl);
+			//Sets each of the options visible if the encription mode is supported
 			pgp.setVisible(Config.supportOpenPgp());
 			none.setVisible(Config.supportUnencrypted() || conversation.getMode() == Conversation.MODE_MULTI);
 			otr.setVisible(Config.supportOtr());
@@ -956,6 +961,12 @@ public class ConversationActivity extends XmppActivity
 					}
 				});
 		builder.create().show();
+	}
+
+	protected void changeBackgroundColorDialog(final Conversation conversation)
+	{
+		//TODO
+		return;
 	}
 
 	public void unmuteConversation(final Conversation conversation) {

--- a/src/main/res/menu/background_color_choice.xml
+++ b/src/main/res/menu/background_color_choice.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <group android:checkableBehavior="single" >
+        <item
+            android:id="@+id/background_color_grey"
+            android:title="@string/background_grey"/>
+        <item
+            android:id="@+id/background_color_red"
+            android:title="@string/background_red"/>
+        <item
+            android:id="@+id/background_color_blue"
+            android:title="@string/background_blue"/>
+    </group>
+
+</menu>

--- a/src/main/res/menu/conversations.xml
+++ b/src/main/res/menu/conversations.xml
@@ -67,4 +67,10 @@
         android:showAsAction="never"
         android:title="@string/action_settings"/>
 
+    <item
+        android:id="@+id/action_change_background_color"
+        android:orderInCategory="110"
+        android:showAsAction="never"
+        android:title="@string/action_change_background_color"/>
+
 </menu>

--- a/src/main/res/values-pt/strings.xml
+++ b/src/main/res/values-pt/strings.xml
@@ -15,6 +15,7 @@
   <string name="action_unblock_contact">Desbloquear contacto</string>
   <string name="action_block_domain">Bloquear domínio</string>
   <string name="action_unblock_domain">Desbloquear domínio</string>
+  <string name="action_change_background_color">Alterar cor de fundo</string>
   <string name="title_activity_manage_accounts">Gerir contas</string>
   <string name="title_activity_settings">Definições</string>
   <string name="title_activity_conference_details">Detalhes da conferência</string>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -5,6 +5,7 @@
 	<color name="primary800">#ff026100</color>
 	<color name="primary900">#ff024500</color>
 	<color name="accent">#ff0091ea</color>
+	<color name="darkblue">#ff410e8e</color>
 	<color name="black87">#de000000</color>
 	<color name="black54">#8a000000</color>
 	<color name="black26">#42000000</color>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
 	<string name="action_block_domain">Block domain</string>
 	<string name="action_unblock_domain">Unblock domain</string>
 	<string name="action_change_background_color">Change Background Color</string>
+	<string name="background_grey">Grey</string>
+	<string name="background_red">Red</string>
+	<string name="background_blue">Blue</string>
 	<string name="title_activity_manage_accounts">Manage Accounts</string>
 	<string name="title_activity_settings">Settings</string>
 	<string name="title_activity_conference_details">Conference Details</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
 	<string name="action_unblock_contact">Unblock contact</string>
 	<string name="action_block_domain">Block domain</string>
 	<string name="action_unblock_domain">Unblock domain</string>
+	<string name="action_change_background_color">Change Background Color</string>
 	<string name="title_activity_manage_accounts">Manage Accounts</string>
 	<string name="title_activity_settings">Settings</string>
 	<string name="title_activity_conference_details">Conference Details</string>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -171,4 +171,52 @@
         <item name="android:background">@drawable/actionbar_tab_indicator</item>
     </style>
 
+    <style name="ConversationsTheme.GreyBackgroundColor" parent="ConversationsTheme">
+        <item name="attr/color_background_secondary">@color/grey200</item>
+    </style>
+
+    <style name="ConversationsTheme.RedBackgroundColor" parent="ConversationsTheme">
+        <item name="attr/color_background_secondary">@color/red500</item>
+    </style>
+
+    <style name="ConversationsTheme.BlueBackgroundColor" parent="ConversationsTheme">
+        <item name="attr/color_background_secondary">@color/accent</item>
+    </style>
+
+    <style name="ConversationsTheme.Dark.GreyBackgroundColor" parent="ConversationsTheme.Dark">
+        <item name="attr/color_background_secondary">@color/grey500</item>
+    </style>
+
+    <style name="ConversationsTheme.Dark.RedBackgroundColor" parent="ConversationsTheme.Dark">
+        <item name="attr/color_background_secondary">@color/red800</item>
+    </style>
+
+    <style name="ConversationsTheme.Dark.BlueBackgroundColor" parent="ConversationsTheme.Dark">
+        <item name="attr/color_background_secondary">@color/darkblue</item>
+    </style>
+
+    <style name="ConversationsTheme.LargerText.GreyBackgroundColor" parent="ConversationsTheme.LargerText">
+        <item name="attr/color_background_secondary">@color/grey200</item>
+    </style>
+
+    <style name="ConversationsTheme.LargerText.RedBackgroundColor" parent="ConversationsTheme.LargerText">
+        <item name="attr/color_background_secondary">@color/red500</item>
+    </style>
+
+    <style name="ConversationsTheme.LargerText.BlueBackgroundColor" parent="ConversationsTheme.LargerText">
+        <item name="attr/color_background_secondary">@color/accent</item>
+    </style>
+
+    <style name="ConversationsTheme.Dark.LargerText.GreyBackgroundColor" parent="ConversationsTheme.Dark.LargerText">
+        <item name="attr/color_background_secondary">@color/grey500</item>
+    </style>
+
+    <style name="ConversationsTheme.Dark.LargerText.RedBackgroundColor" parent="ConversationsTheme.Dark.LargerText">
+        <item name="attr/color_background_secondary">@color/red800</item>
+    </style>
+
+    <style name="ConversationsTheme.Dark.LargerText.BlueBackgroundColor" parent="ConversationsTheme.Dark.LargerText">
+        <item name="attr/color_background_secondary">@color/darkblue</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
In order to complete an University Project, I've added the option, in the Conversation Activity, to change the secondary background color.

- It only has the default("grey") color + blue + red, and they change to a darker tone if the theme is set to "Dark".
- The color type keeps the same even if the theme is changed or larger fonts mode is activated.
- The color keeps even if the app is restarted.

This was done because there was an issue ( #2110 ) mentioning the possibility of background pictures being added to the conversations.
I did not have the time to try to add images, but I could add the option to choose the color, so I did it.