### PR TITLE
Gray out offline contacts in ConferenceDetailsActivity

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentSender.SendIntentException;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
 import android.os.Bundle;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -621,6 +623,12 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 			}
 			ImageView iv = (ImageView) view.findViewById(R.id.contact_photo);
 			iv.setImageBitmap(avatarService().get(user, getPixel(48), false));
+			if (user.getRole() == MucOptions.Role.NONE) {
+				view.setAlpha(0.4f);
+				ColorMatrix colorMatrix = new ColorMatrix();
+				colorMatrix.setSaturation(0f);
+				iv.setColorFilter(new ColorMatrixColorFilter(colorMatrix));
+			}
 			membersView.addView(view);
 			if (mConversation.getMucOptions().canInvite()) {
 				mInviteButton.setVisibility(View.VISIBLE);

--- a/src/main/java/eu/siacs/conversations/ui/widget/NorLinearLayout.java
+++ b/src/main/java/eu/siacs/conversations/ui/widget/NorLinearLayout.java
@@ -1,0 +1,25 @@
+package eu.siacs.conversations.ui.widget;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.LinearLayout;
+
+public class NorLinearLayout extends LinearLayout {
+	public NorLinearLayout(Context context) {
+		super(context);
+	}
+
+	public NorLinearLayout(Context context, AttributeSet attrs) {
+		super(context, attrs);
+	}
+
+	public NorLinearLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+		super(context, attrs, defStyleAttr);
+	}
+
+	@Override
+	public boolean hasOverlappingRendering() {
+		// Makes setAlpha more performant, see https://plus.google.com/+RomanNurik/posts/NSgQvbfXGQN
+		return false;
+	}
+}

--- a/src/main/res/layout/contact.xml
+++ b/src/main/res/layout/contact.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<eu.siacs.conversations.ui.widget.NorLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
                 android:background="?android:attr/activatedBackgroundIndicator"
                 android:padding="8dp">
 
@@ -10,7 +12,6 @@
         android:id="@+id/contact_photo"
         android:layout_width="48dp"
         android:layout_height="48dp"
-        android:layout_alignParentLeft="true"
         android:scaleType="centerCrop"
         android:src="@drawable/ic_profile"
         app:riv_corner_radius="2dp" />
@@ -18,8 +19,6 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        android:layout_toRightOf="@+id/contact_photo"
         android:orientation="vertical"
         android:paddingLeft="8dp" >
 
@@ -56,4 +55,4 @@
             android:visibility="gone" />
     </LinearLayout>
 
-</RelativeLayout>
+</eu.siacs.conversations.ui.widget.NorLinearLayout>


### PR DESCRIPTION
![grayed-out-contact](https://cloud.githubusercontent.com/assets/8524113/21520686/3c9a9374-cd07-11e6-9758-7702d98a8859.png)

This allows to distinguish offline contacts faster. This will be very helpful in large chats.

`NorLinearLayout` will fix some freezes when setAlpha is used over view groups.