### PR TITLE
Stop Conversations force closing over sqlite errors due to long messages

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Message.java
+++ b/src/main/java/eu/siacs/conversations/entities/Message.java
@@ -154,6 +154,8 @@ public class Message extends AbstractEntity {
 			}
 		} catch (InvalidJidException e) {
 			jid = null;
+		} catch (IllegalStateException e) {
+			return null; // message too long?
 		}
 		Jid trueCounterpart;
 		try {

--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -636,8 +636,10 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 			cursor.moveToLast();
 			do {
 				Message message = Message.fromCursor(cursor);
-				message.setConversation(conversation);
-				list.add(message);
+				if (message != null) {
+					message.setConversation(conversation);
+					list.add(message);
+				}
 			} while (cursor.moveToPrevious());
 		}
 		cursor.close();

--- a/src/main/java/eu/siacs/conversations/services/ExportLogsService.java
+++ b/src/main/java/eu/siacs/conversations/services/ExportLogsService.java
@@ -84,6 +84,8 @@ public class ExportLogsService extends Service {
 		BufferedWriter bw = null;
 		try {
 			for (Message message : mDatabaseBackend.getMessagesIterable(conversation)) {
+				if (message == null)
+					continue;
 				if (message.getType() == Message.TYPE_TEXT || message.hasFileOnRemoteHost()) {
 					String date = simpleDateFormat.format(new Date(message.getTimeSent()));
 					if (bw == null) {


### PR DESCRIPTION
I believe the root cause is huge messages, but sometimes every column in a row throws an IllegalStateException, and the only alternative at that point is to ignore the message and move on.

When I queried my database, with the crashing UUID, some of the length(body) were 16364444 which is what leads me to think this is length related.  A better fix would be to allow crazy long messages, but at least this stops conversations from crashing to the point of being unusable forever.