### PR TITLE
New clean process to remove old cache and attachments if using Internal Storage

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -101,6 +101,7 @@ public final class Config {
 	public static final boolean X509_VERIFICATION = false; //use x509 certificates to verify OMEMO keys
 
 	public static final boolean ONLY_INTERNAL_STORAGE = false; //use internal storage instead of sdcard to save attachments
+	public static final long CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 1 Day cache
 
 	public static final boolean IGNORE_ID_REWRITE_IN_MUC = true;
 

--- a/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
@@ -95,6 +95,35 @@ public class FileBackend {
 		}
 	}
 
+	public void cleanInternalStorage(File dir, long timestamp) {
+		File[] dirArray = dir.listFiles();
+		if (dirArray != null) {
+			for (File aDirArray : dirArray) {
+				cleanFilesInSubfolder(aDirArray, timestamp);
+			}
+		}
+	}
+
+	private void cleanFilesInSubfolder(File dir, long timestamp) {
+		try {
+			File[] array = dir.listFiles();
+			if (array != null) {
+				for (File anArray : array) {
+					String name = anArray.getName().toLowerCase();
+					if (name.equals(".nomedia")) {
+						continue;
+					}
+					if (anArray.isFile() && anArray.lastModified() < timestamp) {
+						Log.d("CleanInternalStorage", "Deleting : " + anArray.toString());
+						anArray.delete();
+					}
+				}
+			}
+		} catch (Throwable e) {
+			Log.e("CleanFiles", e.toString());
+		}
+	}
+
 	public boolean deleteFile(Message message) {
 		File file = getFile(message);
 		if (file.delete()) {

--- a/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
@@ -45,6 +45,7 @@ public class SettingsActivity extends XmppActivity implements
 	public static final String MANUALLY_CHANGE_PRESENCE = "manually_change_presence";
 	public static final String BLIND_TRUST_BEFORE_VERIFICATION = "btbv";
 	public static final String AUTOMATIC_MESSAGE_DELETION = "automatic_message_deletion";
+	public static final String AUTOMATIC_PRIVATE_ATTACHMENT_DELETION = "automatic_private_attachment_deletion";
 
 	public static final int REQUEST_WRITE_LOGS = 0xbf8701;
 	private SettingsFragment mSettingsFragment;
@@ -188,26 +189,6 @@ public class SettingsActivity extends XmppActivity implements
 			}
 		});
 
-		if (Config.ONLY_INTERNAL_STORAGE) {
-			final Preference cleanCachePreference = mSettingsFragment.findPreference("clean_cache");
-			cleanCachePreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-				@Override
-				public boolean onPreferenceClick(Preference preference) {
-					cleanCache();
-					return true;
-				}
-			});
-
-			final Preference cleanPrivateStoragePreference = mSettingsFragment.findPreference("clean_private_storage");
-			cleanPrivateStoragePreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-				@Override
-				public boolean onPreferenceClick(Preference preference) {
-					cleanPrivateStorage();
-					return true;
-				}
-			});
-		}
-
 		final Preference deleteOmemoPreference = mSettingsFragment.findPreference("delete_omemo_identities");
 		deleteOmemoPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
 			@Override
@@ -216,57 +197,6 @@ public class SettingsActivity extends XmppActivity implements
 				return true;
 			}
 		});
-	}
-
-	private void cleanCache() {
-		Intent intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-		intent.setData(Uri.parse("package:" + getPackageName()));
-		startActivity(intent);
-	}
-
-	private void cleanPrivateStorage() {
-		cleanPrivatePictures();
-		cleanPrivateFiles();
-	}
-
-	private void cleanPrivatePictures() {
-		try {
-			File dir = new File(getFilesDir().getAbsolutePath(), "/Pictures/");
-			File[] array = dir.listFiles();
-			if (array != null) {
-				for (int b = 0; b < array.length; b++) {
-					String name = array[b].getName().toLowerCase();
-					if (name.equals(".nomedia")) {
-						continue;
-					}
-					if (array[b].isFile()) {
-						array[b].delete();
-					}
-				}
-			}
-		} catch (Throwable e) {
-			Log.e("CleanCache", e.toString());
-		}
-	}
-
-	private void cleanPrivateFiles() {
-		try {
-			File dir = new File(getFilesDir().getAbsolutePath(), "/Files/");
-			File[] array = dir.listFiles();
-			if (array != null) {
-				for (int b = 0; b < array.length; b++) {
-					String name = array[b].getName().toLowerCase();
-					if (name.equals(".nomedia")) {
-						continue;
-					}
-					if (array[b].isFile()) {
-						array[b].delete();
-					}
-				}
-			}
-		} catch (Throwable e) {
-			Log.e("CleanCache", e.toString());
-		}
 	}
 
 	private void deleteOmemoIdentities() {
@@ -374,6 +304,9 @@ public class SettingsActivity extends XmppActivity implements
 			reconnectAccounts();
 		} else if (name.equals(AUTOMATIC_MESSAGE_DELETION)) {
 			xmppConnectionService.expireOldMessages(true);
+		} else if (name.equals(AUTOMATIC_PRIVATE_ATTACHMENT_DELETION)) {
+			xmppConnectionService.expireOldAttachments();
+			xmppConnectionService.expireOldCache();
 		}
 
 	}

--- a/src/main/java/eu/siacs/conversations/ui/SettingsFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsFragment.java
@@ -58,10 +58,8 @@ public class SettingsFragment extends PreferenceFragment {
 		// Remove from standard preferences if the flag ONLY_INTERNAL_STORAGE is not true
 		if (!Config.ONLY_INTERNAL_STORAGE) {
 			PreferenceCategory mCategory = (PreferenceCategory) findPreference("security_options");
-			Preference mPref1 = findPreference("clean_cache");
-			Preference mPref2 = findPreference("clean_private_storage");
+			Preference mPref1 = findPreference("automatic_private_attachment_deletion");
 			mCategory.removePreference(mPref1);
-			mCategory.removePreference(mPref2);
 		}
 
 	}

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -117,4 +117,18 @@
 		<item>@string/timeout_30_days</item>
 		<item>@string/timeout_6_months</item>
 	</string-array>
+	<string-array name="automatic_private_attachment_deletion_values">
+		<item>0</item>
+		<item>86400</item>
+		<item>604800</item>
+		<item>2592000</item>
+		<item>15811200</item>
+	</string-array>
+	<string-array name="automatic_private_attachment_deletion">
+		<item>@string/never</item>
+		<item>@string/timeout_24_hours</item>
+		<item>@string/timeout_7_days</item>
+		<item>@string/timeout_30_days</item>
+		<item>@string/timeout_6_months</item>
+	</string-array>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -730,6 +730,8 @@
 	<string name="timeout_6_months">6 months</string>
 	<string name="pref_automatically_delete_messages">Automatic message deletion</string>
 	<string name="pref_automatically_delete_messages_description">Automatically delete messages from this device that are older than the configured time frame.</string>
+	<string name="pref_automatically_delete_private_attachments">Automatic attachment deletion</string>
+	<string name="pref_automatically_delete_private_attachments_description">Automatically delete attachments from this device that are older than the configured time frame.</string>
 	<string name="encrypting_message">Encrypting message</string>
 	<string name="not_fetching_history_retention_period">Not fetching messages due to local retention period.</string>
 	<string name="transcoding_video_progress">Compressing video (%s%% completed)</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -177,6 +177,13 @@
                     android:defaultValue="0"
                     android:entries="@array/automatic_message_deletion"
                     android:entryValues="@array/automatic_message_deletion_values" />
+                <ListPreference
+                    android:key="automatic_private_attachment_deletion"
+                    android:title="@string/pref_automatically_delete_private_attachments"
+                    android:summary="@string/pref_automatically_delete_private_attachments_description"
+                    android:defaultValue="0"
+                    android:entries="@array/automatic_private_attachment_deletion"
+                    android:entryValues="@array/automatic_private_attachment_deletion_values" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="dont_trust_system_cas"
@@ -191,14 +198,6 @@
                     android:key="allow_message_correction"
                     android:title="@string/pref_allow_message_correction"
                     android:summary="@string/pref_allow_message_correction_summary"/>
-                <Preference
-                    android:key="clean_cache"
-                    android:summary="@string/pref_clean_cache_summary"
-                    android:title="@string/pref_clean_cache"/>
-                <Preference
-                    android:key="clean_private_storage"
-                    android:summary="@string/pref_clean_private_storage_summary"
-                    android:title="@string/pref_clean_private_storage"/>
                 <Preference
                     android:key="delete_omemo_identities"
                     android:title="@string/pref_delete_omemo_identities"


### PR DESCRIPTION
Hi, taking steps towards what we talked about in https://github.com/siacs/Conversations/pull/2072:
- An automatic clean process is going to be started every time the program starts
- Clean process removes cache files older than Config.CACHE_MAX_AGE
- Private files are going to be cleaned after a defined time via settings (similar to expire messages)

This way everything becomes much cleaner.

![settings](https://cloud.githubusercontent.com/assets/317067/22824822/1429cf40-ef8a-11e6-87e4-bd54bfb4d387.jpg)![settings2](https://cloud.githubusercontent.com/assets/317067/22824823/142b0004-ef8a-11e6-9bd2-84263469ef8f.jpg)



