### PR TITLE
Add a check box to enable anonymous login

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -42,6 +42,7 @@ public final class Config {
 	public static final String DOMAIN_LOCK = null; //only allow account creation for this domain
 	public static final String MAGIC_CREATE_DOMAIN = "conversations.im";
 	public static final boolean DISALLOW_REGISTRATION_IN_UI = false; //hide the register checkbox
+	public static final boolean DISALLOW_ANON_LOGIN = false; // hide the anonymous login check and disable SASL mechanism.
 
 	public static final boolean ALLOW_NON_TLS_CONNECTIONS = false; //very dangerous. you should have a good reason to set this to true
 	public static final boolean FORCE_ORBOT = false; // always use TOR

--- a/src/main/java/eu/siacs/conversations/entities/ServiceDiscoveryResult.java
+++ b/src/main/java/eu/siacs/conversations/entities/ServiceDiscoveryResult.java
@@ -15,6 +15,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import eu.siacs.conversations.Config;
 import eu.siacs.conversations.xml.Element;
 import eu.siacs.conversations.xmpp.forms.Data;
 import eu.siacs.conversations.xmpp.forms.Field;

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -46,9 +46,9 @@ import eu.siacs.conversations.crypto.axolotl.AxolotlService;
 import eu.siacs.conversations.crypto.axolotl.XmppAxolotlSession;
 import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.services.BarcodeProvider;
-import eu.siacs.conversations.services.XmppConnectionService.OnCaptchaRequested;
 import eu.siacs.conversations.services.XmppConnectionService;
 import eu.siacs.conversations.services.XmppConnectionService.OnAccountUpdate;
+import eu.siacs.conversations.services.XmppConnectionService.OnCaptchaRequested;
 import eu.siacs.conversations.ui.adapter.KnownHostsAdapter;
 import eu.siacs.conversations.utils.CryptoHelper;
 import eu.siacs.conversations.utils.UIHelper;
@@ -94,6 +94,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 	private TextView mAxolotlFingerprint;
 	private TextView mOwnFingerprintDesc;
 	private TextView mAccountJidLabel;
+	private TextView mAccountPasswordLabel;
 	private ImageView mAvatar;
 	private RelativeLayout mOtrFingerprintBox;
 	private RelativeLayout mAxolotlFingerprintBox;
@@ -183,7 +184,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 				}
 			}
 
-			if (jid.isDomainJid()) {
+			if (jid.isDomainJid() && !getPreferences().getBoolean(SettingsActivity.ENABLE_ANON_LOGIN, false)) {
 				if (mUsernameMode) {
 					mAccountJid.setError(getString(R.string.invalid_username));
 				} else {
@@ -481,12 +482,14 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 		this.mAccountJid = (AutoCompleteTextView) findViewById(R.id.account_jid);
 		this.mAccountJid.addTextChangedListener(this.mTextWatcher);
 		this.mAccountJidLabel = (TextView) findViewById(R.id.account_jid_label);
+		this.mAccountPasswordLabel = (TextView) findViewById(R.id.account_password_label);
 		this.mPassword = (EditText) findViewById(R.id.account_password);
 		this.mPassword.addTextChangedListener(this.mTextWatcher);
 		this.mPasswordConfirm = (EditText) findViewById(R.id.account_password_confirm);
 		this.mAvatar = (ImageView) findViewById(R.id.avater);
 		this.mAvatar.setOnClickListener(this.mAvatarClickListener);
 		this.mRegisterNew = (CheckBox) findViewById(R.id.account_register_new);
+		final CheckBox mLoginAnon = (CheckBox) findViewById(R.id.account_use_anon);
 		this.mStats = (LinearLayout) findViewById(R.id.stats);
 		this.mOsOptimizations = (RelativeLayout) findViewById(R.id.os_optimization);
 		this.mDisableOsOptimizationsButton = (Button) findViewById(R.id.os_optimization_disable);
@@ -545,9 +548,30 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 				updateSaveButton();
 			}
 		};
+		final OnCheckedChangeListener OnCheckedHideLogin = new OnCheckedChangeListener() {
+			@Override
+			public void onCheckedChanged(final CompoundButton buttonView,
+			                             final boolean isChecked) {
+				if (isChecked) {
+					mRegisterNew.setVisibility(View.GONE);
+					mPassword.setVisibility(View.GONE);
+					mAccountPasswordLabel.setVisibility(View.GONE);
+				} else {
+					mRegisterNew.setVisibility(View.VISIBLE);
+					mPassword.setVisibility(View.VISIBLE);
+					mAccountPasswordLabel.setVisibility(View.VISIBLE);
+				}
+				getPreferences().edit().putBoolean(SettingsActivity.ENABLE_ANON_LOGIN, isChecked).apply();
+				updateSaveButton();
+			}
+		};
 		this.mRegisterNew.setOnCheckedChangeListener(OnCheckedShowConfirmPassword);
+		mLoginAnon.setOnCheckedChangeListener(OnCheckedHideLogin);
 		if (Config.DISALLOW_REGISTRATION_IN_UI) {
 			this.mRegisterNew.setVisibility(View.GONE);
+		}
+		if (Config.DISALLOW_ANON_LOGIN) {
+			mLoginAnon.setVisibility(View.GONE);
 		}
 	}
 

--- a/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
@@ -45,6 +45,7 @@ public class SettingsActivity extends XmppActivity implements
 	public static final String MANUALLY_CHANGE_PRESENCE = "manually_change_presence";
 	public static final String BLIND_TRUST_BEFORE_VERIFICATION = "btbv";
 	public static final String AUTOMATIC_MESSAGE_DELETION = "automatic_message_deletion";
+	public static final String ENABLE_ANON_LOGIN = "enable_anon_login";
 
 	public static final int REQUEST_WRITE_LOGS = 0xbf8701;
 	private SettingsFragment mSettingsFragment;

--- a/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
@@ -52,18 +52,12 @@ import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.Toast;
 
-import com.google.zxing.BarcodeFormat;
-import com.google.zxing.EncodeHintType;
-import com.google.zxing.aztec.AztecWriter;
-import com.google.zxing.common.BitMatrix;
-
 import net.java.otr4j.session.SessionID;
 
 import java.io.FileNotFoundException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;

--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -7,6 +7,7 @@ import android.os.Parcelable;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
 import android.os.SystemClock;
+import android.preference.PreferenceManager;
 import android.security.KeyChain;
 import android.util.Base64;
 import android.util.Log;
@@ -65,6 +66,7 @@ import eu.siacs.conversations.entities.Message;
 import eu.siacs.conversations.entities.ServiceDiscoveryResult;
 import eu.siacs.conversations.generator.IqGenerator;
 import eu.siacs.conversations.services.XmppConnectionService;
+import eu.siacs.conversations.ui.SettingsActivity;
 import eu.siacs.conversations.utils.DNSHelper;
 import eu.siacs.conversations.utils.SSLSocketHelper;
 import eu.siacs.conversations.utils.SocksSocketFactory;
@@ -862,7 +864,8 @@ public class XmppConnection implements Runnable {
 			saslMechanism = new Plain(tagWriter, account);
 		} else if (mechanisms.contains("DIGEST-MD5")) {
 			saslMechanism = new DigestMd5(tagWriter, account, mXmppConnectionService.getRNG());
-		} else if (mechanisms.contains("ANONYMOUS")) {
+		} else if (mechanisms.contains("ANONYMOUS") &&
+				PreferenceManager.getDefaultSharedPreferences(mXmppConnectionService.getApplicationContext()).getBoolean(SettingsActivity.ENABLE_ANON_LOGIN, false)) {
 			saslMechanism = new Anonymous(tagWriter, account, mXmppConnectionService.getRNG());
 		}
 		if (saslMechanism != null) {

--- a/src/main/res/layout/activity_edit_account.xml
+++ b/src/main/res/layout/activity_edit_account.xml
@@ -61,6 +61,7 @@
                         android:textSize="?attr/TextSizeBody"/>
 
                     <TextView
+                        android:id="@+id/account_password_label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="8dp"
@@ -136,6 +137,15 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="8dp"
                         android:text="@string/register_account"
+                        android:textColor="?attr/color_text_primary"
+                        android:textSize="?attr/TextSizeBody"/>
+
+                    <CheckBox
+                        android:id="@+id/account_use_anon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/use_anon_login"
                         android:textColor="?attr/color_text_primary"
                         android:textSize="?attr/TextSizeBody"/>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
 	<string name="contact_blocked">Contact blocked</string>
 	<string name="remove_bookmark_text">Would you like to remove %s as a bookmark? The conversation associated with this bookmark will not be removed.</string>
 	<string name="register_account">Register new account on server</string>
+	<string name="use_anon_login">Login anonymously</string>
 	<string name="change_password_on_server">Change password on server</string>
 	<string name="share_with">Share with…</string>
 	<string name="start_conversation">Start Conversation</string>


### PR DESCRIPTION
A bit more UI around logging in with SASL ANONYMOUS.

This adds a checkbox to the login screen; for clients built with a pinned server it may make sense to go ahead and start the handshake process and only show this check box if we know that the server supports anonymous login, but I left that as a future optimization.

I'm not sure if this is even desired, but it was something to do on one leg of the flight back from summit. Only tested without actually having a network, but it appeared to be working.