### PR TITLE
Adds feature requested in #2181 : Unread count for each conversation

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/adapter/ConversationAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/ConversationAdapter.java
@@ -25,6 +25,7 @@ import eu.siacs.conversations.entities.Message;
 import eu.siacs.conversations.entities.Transferable;
 import eu.siacs.conversations.ui.ConversationActivity;
 import eu.siacs.conversations.ui.XmppActivity;
+import eu.siacs.conversations.ui.widget.UnreadCountCustomView;
 import eu.siacs.conversations.utils.UIHelper;
 
 public class ConversationAdapter extends ArrayAdapter<Conversation> {
@@ -62,6 +63,7 @@ public class ConversationAdapter extends ArrayAdapter<Conversation> {
 		ImageView notificationStatus = (ImageView) view.findViewById(R.id.notification_status);
 
 		Message message = conversation.getLatestMessage();
+		int unreadCount = conversation.unreadCount();
 
 		if (!conversation.isRead()) {
 			convName.setTypeface(null, Typeface.BOLD);
@@ -79,6 +81,13 @@ public class ConversationAdapter extends ArrayAdapter<Conversation> {
 			Pair<String,Boolean> preview = UIHelper.getMessagePreview(activity,message);
 			mLastMessage.setVisibility(View.VISIBLE);
 			imagePreview.setVisibility(View.GONE);
+			UnreadCountCustomView unreadCountCustomView = (UnreadCountCustomView) view.findViewById(R.id.unread_count);
+			if (unreadCount > 0) {
+				unreadCountCustomView.setVisibility(View.VISIBLE);
+				unreadCountCustomView.setUnreadCount(unreadCount);
+			} else {
+				unreadCountCustomView.setVisibility(View.GONE);
+			}
 			mLastMessage.setText(preview.first);
 			if (preview.second) {
 				if (conversation.isRead()) {

--- a/src/main/java/eu/siacs/conversations/ui/widget/UnreadCountCustomView.java
+++ b/src/main/java/eu/siacs/conversations/ui/widget/UnreadCountCustomView.java
@@ -1,0 +1,76 @@
+package eu.siacs.conversations.ui.widget;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Typeface;
+import android.support.v4.content.ContextCompat;
+import android.util.AttributeSet;
+import android.view.View;
+
+import eu.siacs.conversations.R;
+
+public class UnreadCountCustomView extends View {
+
+    private int unreadCount;
+    private Paint paint, textPaint;
+    private int backgroundColor = 0xff326130;
+
+    public UnreadCountCustomView(Context context) {
+        super(context);
+        init();
+    }
+
+    public UnreadCountCustomView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initXMLAttrs(context, attrs);
+        init();
+    }
+
+    public UnreadCountCustomView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        initXMLAttrs(context, attrs);
+        init();
+    }
+
+    private void initXMLAttrs(Context context, AttributeSet attrs) {
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.UnreadCountCustomView);
+        setBackgroundColor(a.getColor(a.getIndex(0), ContextCompat.getColor(context, R.color.unreadcountlight)));
+        a.recycle();
+    }
+
+    void init() {
+        paint = new Paint();
+        paint.setColor(backgroundColor);
+        paint.setAntiAlias(true);
+        textPaint = new Paint();
+        textPaint.setColor(Color.WHITE);
+        textPaint.setTextAlign(Paint.Align.CENTER);
+        textPaint.setAntiAlias(true);
+        textPaint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        float midx = canvas.getWidth() / 2.0f;
+        float midy = canvas.getHeight() / 2.0f;
+        float radius = Math.min(canvas.getWidth(), canvas.getHeight()) / 2.0f;
+        float textOffset = canvas.getWidth() / 6.0f;
+        textPaint.setTextSize(0.95f * radius);
+        canvas.drawCircle(midx, midy, radius * 0.94f, paint);
+        canvas.drawText(String.valueOf(unreadCount), midx, midy + textOffset, textPaint);
+
+    }
+
+    public void setUnreadCount(int unreadCount) {
+        this.unreadCount = unreadCount;
+        invalidate();
+    }
+
+    public void setBackgroundColor(int backgroundColor) {
+        this.backgroundColor = backgroundColor;
+    }
+}

--- a/src/main/res/layout/conversation_list_row.xml
+++ b/src/main/res/layout/conversation_list_row.xml
@@ -59,10 +59,11 @@
 
                     <LinearLayout android:layout_width="match_parent"
                                   android:layout_height="wrap_content"
-                                  android:layout_alignParentLeft="true"
                                   android:layout_centerVertical="true"
+                                  android:orientation="vertical"
+                                  android:layout_alignParentLeft="true"
                                   android:layout_toLeftOf="@+id/notification_status"
-                                  android:orientation="vertical">
+                                  android:id="@+id/txt_img_wrapper">
                         <TextView
                             android:id="@+id/conversation_lastmsg"
                             android:layout_width="match_parent"
@@ -89,11 +90,24 @@
                         android:id="@+id/notification_status"
                         android:layout_width="?attr/IconSize"
                         android:layout_height="?attr/IconSize"
-                        android:layout_alignParentRight="true"
+                        android:layout_toLeftOf="@+id/unread_count"
+                        android:layout_alignWithParentIfMissing="true"
                         android:layout_centerVertical="true"
                         android:layout_marginLeft="4dp"
                         android:src="?attr/icon_notifications"
                         />
+                    <eu.siacs.conversations.ui.widget.UnreadCountCustomView
+                        android:id="@+id/unread_count"
+                        android:layout_width="?attr/IconSize"
+                        android:layout_height="?attr/IconSize"
+                        android:layout_centerVertical="true"
+                        android:layout_marginLeft="3dp"
+                        android:layout_marginTop="2dp"
+                        android:layout_marginBottom="1dp"
+                        android:visibility="gone"
+                        android:layout_alignParentRight="true"
+                        app:backgroundColor="?attr/unread_count" />
+
                 </RelativeLayout>
 
                 <TextView

--- a/src/main/res/values-v21/themes.xml
+++ b/src/main/res/values-v21/themes.xml
@@ -40,6 +40,8 @@
         <item name="attr/message_bubble_sent">@drawable/message_bubble_sent</item>
         <item name="attr/message_bubble_received_green">@drawable/message_bubble_received</item>
 
+        <item name="attr/unread_count">@color/unreadcountlight</item>
+
         <item name="attr/conversations_overview_background">@color/primary700</item>
 
         <item name="attr/icon_alpha">0.54</item>
@@ -114,6 +116,8 @@
         <item name="attr/message_bubble_received_monochrome">@drawable/message_bubble_received_grey</item>
         <item name="attr/message_bubble_sent">@drawable/message_bubble_sent_grey</item>
         <item name="attr/message_bubble_received_green">@drawable/message_bubble_received_dark</item>
+
+        <item name="attr/unread_count">@color/unreadcountdark</item>
 
         <item name="attr/conversations_overview_background">@color/primary900</item>
 

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -31,6 +31,8 @@
     <attr name="message_bubble_sent" format="reference"/>
     <attr name="message_bubble_received_green" format="reference"/>
 
+    <attr name="unread_count" format="reference|color" />
+
     <attr name="conversations_overview_background" format="reference|color"/>
 
     <attr name="icon_alpha" format="float"/>
@@ -65,5 +67,9 @@
 
     <attr name="dialog_horizontal_padding" format="dimension"/>
     <attr name="dialog_vertical_padding" format="dimension"/>
+
+    <declare-styleable name="UnreadCountCustomView">
+        <attr name="backgroundColor" format="reference|color"/>
+    </declare-styleable>
 
 </resources>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -22,4 +22,6 @@
 	<color name="orange500">#ffff9800</color>
 	<color name="green500">#ff259b24</color>
 	<color name="bubble">#ff4b9b4a</color>
+	<color name="unreadcountlight">#ff4b9b4a</color>
+	<color name="unreadcountdark">#ff326130</color>
 </resources>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -46,6 +46,8 @@
         <item name="attr/message_bubble_sent">@drawable/message_bubble_sent</item>
         <item name="attr/message_bubble_received_green">@drawable/message_bubble_received</item>
 
+        <item name="attr/unread_count">@color/unreadcountlight</item>
+
         <item name="attr/conversations_overview_background">@color/primary700</item>
 
         <item name="attr/icon_alpha">1.0</item>
@@ -107,6 +109,8 @@
         <item name="attr/message_bubble_received_monochrome">@drawable/message_bubble_received_grey</item>
         <item name="attr/message_bubble_sent">@drawable/message_bubble_sent_grey</item>
         <item name="attr/message_bubble_received_green">@drawable/message_bubble_received_dark</item>
+
+        <item name="attr/unread_count">@color/unreadcountdark</item>
 
         <item name="attr/conversations_overview_background">@color/primary900</item>
 


### PR DESCRIPTION
This PR aims to add number of unread messages for each conversation as discussed on #2181 . Until now, the unread count is displayed as : 
![screenshot_2017-03-03-03-59-54-139_eu siacs conversations](https://cloud.githubusercontent.com/assets/16576273/23530416/974166c0-ffc7-11e6-9787-b355940d5dfa.png)
