### PR TITLE
Adds Download button for oob links (XEP-0066)

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -762,7 +762,7 @@ public class MessageAdapter extends ArrayAdapter<Message> implements CopyTextVie
 				displayLocationMessage(viewHolder,message);
 			} else if (message.bodyIsHeart()) {
 				displayHeartMessage(viewHolder, message.getBody().trim());
-			} else if (message.treatAsDownloadable() == Message.Decision.MUST) {
+			} else if (message.treatAsDownloadable() == Message.Decision.MUST || message.treatAsDownloadable() == Message.Decision.SHOULD) {
 				try {
 					URL url = new URL(message.getBody());
 					displayDownloadableMessage(viewHolder,


### PR DESCRIPTION
Attempt to fix https://github.com/siacs/Conversations/issues/2359
Instead of a link, a download button appears in it's place.

Before:
![screenshot_20170311-010623](https://cloud.githubusercontent.com/assets/10472699/23810525/f53deaa6-05f7-11e7-859f-8ecfc43e7452.png)
After:
![screenshot_20170311-010805](https://cloud.githubusercontent.com/assets/10472699/23810527/f8daf8a2-05f7-11e7-9192-0e914cd662de.png)
