### PR TITLE
Added a "Check 'End this conversation' by default" option in settings

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -759,6 +759,7 @@ public class ConversationActivity extends XmppActivity
 				R.layout.dialog_clear_history, null);
 		final CheckBox endConversationCheckBox = (CheckBox) dialogView
 				.findViewById(R.id.end_conversation_checkbox);
+		endConversationCheckBox.setChecked(alwaysAlsoEndConversation());
 		builder.setView(dialogView);
 		builder.setNegativeButton(getString(R.string.cancel), null);
 		builder.setPositiveButton(getString(R.string.delete_messages),
@@ -1722,6 +1723,10 @@ public class ConversationActivity extends XmppActivity
 
 	public boolean useGreenBackground() {
 		return getPreferences().getBoolean("use_green_background",true);
+	}
+
+	public boolean alwaysAlsoEndConversation() {
+		return getPreferences().getBoolean("always_also_end_conversation",false);
 	}
 
 	protected boolean trustKeysIfNeeded(int requestCode) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -741,4 +741,6 @@
 	<string name="pref_notifications_from_strangers">Notifications from strangers</string>
 	<string name="pref_notifications_from_strangers_summary">Notify for messages received from strangers.</string>
 	<string name="received_message_from_stranger">Received message from stranger</string>
+    <string name="pref_always_also_end_conversation">Check \"End this conversation\" by default</string>
+    <string name="pref_always_also_end_conversation_summary">Always end conversation after cleaning history</string>
 </resources>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -161,6 +161,11 @@
             android:key="show_dynamic_tags"
             android:summary="@string/pref_show_dynamic_tags_summary"
             android:title="@string/pref_show_dynamic_tags"/>
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="always_also_end_conversation"
+            android:summary="@string/pref_always_also_end_conversation_summary"
+            android:title="@string/pref_always_also_end_conversation"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:key="advanced"


### PR DESCRIPTION
p.4 from [#2364](https://github.com/siacs/Conversations/issues/2364) 
User can check this option in settings. After that, the "End this conversation afterwards" option will be checked by default in "Clear conversation history" menu.
![screen](https://cloud.githubusercontent.com/assets/14179648/24018591/16c37e9c-0ac7-11e7-8096-d8f43f44e1c3.jpg)

