### PR TITLE
Changes deprecated getResources().getColor() method

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -14,6 +14,7 @@ import android.support.v4.app.NotificationCompat.BigPictureStyle;
 import android.support.v4.app.NotificationCompat.Builder;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.app.RemoteInput;
+import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.text.SpannableString;
 import android.text.style.StyleSpan;
@@ -223,7 +224,7 @@ public class NotificationService {
 	}
 
 	private void setNotificationColor(final Builder mBuilder) {
-		mBuilder.setColor(mXmppConnectionService.getResources().getColor(R.color.primary500));
+		mBuilder.setColor(ContextCompat.getColor(mXmppConnectionService, R.color.primary500));
 	}
 
 	public void updateNotification(final boolean notify) {

--- a/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
@@ -13,6 +13,7 @@ import android.preference.PreferenceManager;
 import android.provider.ContactsContract.CommonDataKinds;
 import android.provider.ContactsContract.Contacts;
 import android.provider.ContactsContract.Intents;
+import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -452,7 +453,7 @@ public class ContactDetailsActivity extends OmemoActivity implements OnAccountUp
 				key.setText(CryptoHelper.prettifyFingerprint(otrFingerprint));
 				if (otrFingerprint != null && otrFingerprint.equals(messageFingerprint)) {
 					keyType.setText(R.string.otr_fingerprint_selected_message);
-					keyType.setTextColor(getResources().getColor(R.color.accent));
+					keyType.setTextColor(ContextCompat.getColor(this, R.color.accent));
 				} else {
 					keyType.setText(R.string.otr_fingerprint);
 				}
@@ -501,7 +502,7 @@ public class ContactDetailsActivity extends OmemoActivity implements OnAccountUp
 			TextView keyType = (TextView) view.findViewById(R.id.key_type);
 			keyType.setText(R.string.openpgp_key_id);
 			if ("pgp".equals(messageFingerprint)) {
-				keyType.setTextColor(getResources().getColor(R.color.accent));
+				keyType.setTextColor(ContextCompat.getColor(this, R.color.accent));
 			}
 			key.setText(OpenPgpUtils.convertKeyIdToHex(contact.getPgpKeyId()));
 			view.setOnClickListener(new OnClickListener() {

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -14,6 +14,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
+import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.Menu;
@@ -922,7 +923,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 			if (ownAxolotlFingerprint != null && Config.supportOmemo()) {
 				this.mAxolotlFingerprintBox.setVisibility(View.VISIBLE);
 				if (ownAxolotlFingerprint.equals(messageFingerprint)) {
-					this.mOwnFingerprintDesc.setTextColor(getResources().getColor(R.color.accent));
+					this.mOwnFingerprintDesc.setTextColor(ContextCompat.getColor(this, R.color.accent));
 				} else {
 					this.mOwnFingerprintDesc.setTextColor(getSecondaryTextColor());
 				}

--- a/src/main/java/eu/siacs/conversations/ui/OmemoActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/OmemoActivity.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.view.ContextMenu;
 import android.view.MenuItem;
 import android.view.View;
@@ -228,7 +229,7 @@ public abstract class OmemoActivity extends XmppActivity {
             keyType.setVisibility(View.GONE);
         }
         if (highlight) {
-            keyType.setTextColor(getResources().getColor(R.color.accent));
+            keyType.setTextColor(ContextCompat.getColor(this, R.color.accent));
             keyType.setText(getString(x509 ? R.string.omemo_fingerprint_x509_selected_message : R.string.omemo_fingerprint_selected_message));
         } else {
             keyType.setText(getString(x509 ? R.string.omemo_fingerprint_x509 : R.string.omemo_fingerprint));

--- a/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
@@ -42,6 +42,7 @@ import android.os.IBinder;
 import android.os.PowerManager;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
+import android.support.v4.content.ContextCompat;
 import android.text.InputType;
 import android.util.DisplayMetrics;
 import android.util.Pair;
@@ -379,22 +380,22 @@ public abstract class XmppActivity extends Activity {
 		metrics = getResources().getDisplayMetrics();
 		ExceptionHelper.init(getApplicationContext());
 
-		mPrimaryTextColor = getResources().getColor(R.color.black87);
-		mSecondaryTextColor = getResources().getColor(R.color.black54);
-		mTertiaryTextColor = getResources().getColor(R.color.black12);
-		mColorRed = getResources().getColor(R.color.red800);
-		mColorOrange = getResources().getColor(R.color.orange500);
-		mColorGreen = getResources().getColor(R.color.green500);
-		mPrimaryColor = getResources().getColor(R.color.primary500);
-		mPrimaryBackgroundColor = getResources().getColor(R.color.grey50);
-		mSecondaryBackgroundColor = getResources().getColor(R.color.grey200);
+		mPrimaryTextColor = ContextCompat.getColor(this, R.color.black87);
+		mSecondaryTextColor = ContextCompat.getColor(this, R.color.black54);
+		mTertiaryTextColor = ContextCompat.getColor(this, R.color.black12);
+		mColorRed = ContextCompat.getColor(this, R.color.red800);
+		mColorOrange = ContextCompat.getColor(this, R.color.orange500);
+		mColorGreen = ContextCompat.getColor(this, R.color.green500);
+		mPrimaryColor = ContextCompat.getColor(this, R.color.primary500);
+		mPrimaryBackgroundColor = ContextCompat.getColor(this, R.color.grey50);
+		mSecondaryBackgroundColor = ContextCompat.getColor(this, R.color.grey200);
 
 		if(isDarkTheme()) {
-			mPrimaryTextColor = getResources().getColor(R.color.white);
-			mSecondaryTextColor = getResources().getColor(R.color.white70);
-			mTertiaryTextColor = getResources().getColor(R.color.white12);
-			mPrimaryBackgroundColor = getResources().getColor(R.color.grey800);
-			mSecondaryBackgroundColor = getResources().getColor(R.color.grey900);
+			mPrimaryTextColor = ContextCompat.getColor(this, R.color.white);
+			mSecondaryTextColor = ContextCompat.getColor(this, R.color.white70);
+			mTertiaryTextColor = ContextCompat.getColor(this, R.color.white12);
+			mPrimaryBackgroundColor = ContextCompat.getColor(this, R.color.grey800);
+			mSecondaryBackgroundColor = ContextCompat.getColor(this, R.color.grey900);
 		}
 
 		this.mTheme = findTheme();

--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -11,6 +11,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.support.v4.content.ContextCompat;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
@@ -153,9 +154,9 @@ public class MessageAdapter extends ArrayAdapter<Message> implements CopyTextVie
 
 	private int getMessageTextColor(boolean onDark, boolean primary) {
 		if (onDark) {
-			return activity.getResources().getColor(primary ? R.color.white : R.color.white70);
+			return ContextCompat.getColor(activity, primary ? R.color.white : R.color.white70);
 		} else {
-			return activity.getResources().getColor(primary ? R.color.black87 : R.color.black54);
+			return ContextCompat.getColor(activity, primary ? R.color.black87 : R.color.black54);
 		}
 	}
 
@@ -332,7 +333,7 @@ public class MessageAdapter extends ArrayAdapter<Message> implements CopyTextVie
 			body.setSpan(new DividerSpan(false), end, end + 2, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 		}
 		int color = darkBackground ? this.getMessageTextColor(darkBackground, false)
-				: getContext().getResources().getColor(R.color.bubble);
+				: ContextCompat.getColor(activity, R.color.bubble);
 		DisplayMetrics metrics = getContext().getResources().getDisplayMetrics();
 		body.setSpan(new QuoteSpan(color, metrics), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 		return 0;
@@ -472,7 +473,7 @@ public class MessageAdapter extends ArrayAdapter<Message> implements CopyTextVie
 		}
 		viewHolder.messageBody.setTextColor(this.getMessageTextColor(darkBackground, true));
 		viewHolder.messageBody.setLinkTextColor(this.getMessageTextColor(darkBackground, true));
-		viewHolder.messageBody.setHighlightColor(activity.getResources().getColor(darkBackground
+		viewHolder.messageBody.setHighlightColor(ContextCompat.getColor(activity, darkBackground
 				? (type == SENT || !mUseGreenBackground ? R.color.black26 : R.color.grey800) : R.color.grey500));
 		viewHolder.messageBody.setTypeface(null, Typeface.NORMAL);
 	}

--- a/src/main/java/eu/siacs/conversations/ui/forms/FormFieldWrapper.java
+++ b/src/main/java/eu/siacs/conversations/ui/forms/FormFieldWrapper.java
@@ -1,6 +1,7 @@
 package eu.siacs.conversations.ui.forms;
 
 import android.content.Context;
+import android.support.v4.content.ContextCompat;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
@@ -59,7 +60,7 @@ public abstract class FormFieldWrapper {
 			int start = label.length();
 			int end = label.length() + 2;
 			spannableString.setSpan(new StyleSpan(android.graphics.Typeface.BOLD), start, end, 0);
-			spannableString.setSpan(new ForegroundColorSpan(context.getResources().getColor(R.color.accent)), start, end, 0);
+			spannableString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(context, R.color.accent)), start, end, 0);
 		}
 		return spannableString;
 	}


### PR DESCRIPTION
This PR changes the deprecated `getResources.getColor()` method to `ContextCompat.getColor()`. A detailed explanation is given on [StackOverflow](http://stackoverflow.com/questions/31590714/getcolorint-id-deprecated-on-android-6-0-marshmallow-api-23).