### PR TITLE
Typing notification for group chats - Fixes #1823 and also fixes #2312

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -193,9 +193,6 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
 	}
 
 	public boolean setOutgoingChatState(ChatState state) {
-		if (mode == MODE_MULTI && (getNextCounterpart() != null || !isPnNA())) {
-			return false;
-		}
 		if (this.mOutgoingChatState != state) {
 			this.mOutgoingChatState = state;
 			return true;


### PR DESCRIPTION
Make sure you have enabled sending typing notifications under *Settings->Typing Notifications*.

![unnamed](https://cloud.githubusercontent.com/assets/11996726/24519487/fa59ba46-15a2-11e7-9e70-e8b3766675df.jpg)
