### PR TITLE
Added preference to control Heads-up Notifications (turned off by default)

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -283,6 +283,7 @@ public class NotificationService {
 		final String ringtone = preferences.getString("notification_ringtone", null);
 		final boolean vibrate = preferences.getBoolean("vibrate_on_notification", true);
 		final boolean led = preferences.getBoolean("led", true);
+		final boolean headsup = preferences.getBoolean("notification_headsup", mXmppConnectionService.getResources().getBoolean(R.bool.headsup_notifications));
 		if (notify && !isQuietHours()) {
 			if (vibrate) {
 				final int dat = 70;
@@ -303,7 +304,7 @@ public class NotificationService {
 		if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 			mBuilder.setCategory(Notification.CATEGORY_MESSAGE);
 		}
-		mBuilder.setPriority(notify ? NotificationCompat.PRIORITY_DEFAULT : NotificationCompat.PRIORITY_LOW);
+		mBuilder.setPriority(notify ? (headsup ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT) : NotificationCompat.PRIORITY_LOW);
 		setNotificationColor(mBuilder);
 		mBuilder.setDefaults(0);
 		if (led) {

--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -4,4 +4,5 @@
     <bool name="portrait_only">true</bool>
     <bool name="enter_is_send">false</bool>
     <bool name="notifications_from_strangers">false</bool>
+    <bool name="headsup_notifications">false</bool>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -752,4 +752,6 @@
 	<string name="account_status_regis_web">Server requires registration on website</string>
 	<string name="open_website">Open website</string>
 	<string name="application_found_to_open_website">No application found to open website</string>
+	<string name="pref_headsup_notifications">Heads-up Notifications</string>
+	<string name="pref_headsup_notifications_summary">Show Heads-up Notifications</string>
 </resources>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -66,6 +66,12 @@
             android:ringtoneType="notification"
             android:summary="@string/pref_sound_summary"
             android:title="@string/pref_sound"/>
+        <CheckBoxPreference
+            android:defaultValue="@bool/headsup_notifications"
+            android:dependency="show_notification"
+            android:key="notification_headsup"
+            android:title="@string/pref_headsup_notifications"
+            android:summary="@string/pref_headsup_notifications_summary"/>
         <PreferenceScreen
             android:dependency="show_notification"
             android:key="quiet_hours"


### PR DESCRIPTION
I didn't like that I was only notified by a small icon in the notification bar when I'm using my phone while it's muted, so I think this feature, which is also available in other mobile messengers (and usually enabled by default), might be a good idea. 
Since it's disabled by default most users shouldn't notice the change unless they manually enable it. 