### PR TITLE
Give up PGP decryption when intent is cancelled

### DIFF
--- a/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
+++ b/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
@@ -69,6 +69,27 @@ public class PgpDecryptionService {
         this.pendingNotifications.remove(message);
     }
 
+    public void giveUpCurrentDecryption(){
+        Message message;
+        synchronized (this) {
+            if(currentMessage != null) {
+                return;
+            }
+            message = messages.peekFirst();
+            if (message == null) {
+                return;
+            }
+            discard(message);
+        }
+        synchronized (message){
+            if (message.getEncryption() == Message.ENCRYPTION_PGP) {
+                message.setEncryption(Message.ENCRYPTION_DECRYPTION_FAILED);
+            }
+        }
+        mXmppConnectionService.updateMessage(message);
+        continueDecryption(true);
+    }
+
 	protected synchronized void decryptNext() {
 		if (pendingIntent == null
                 && getOpenPgpApi() != null

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -1658,6 +1658,11 @@ public class ConversationFragment extends Fragment implements EditMessage.Keyboa
 				int choice = data.getIntExtra("choice", ConversationActivity.ATTACHMENT_CHOICE_INVALID);
 				activity.selectPresenceToAttachFile(choice, conversation.getNextEncryption());
 			}
+		} else if (resultCode == Activity.RESULT_CANCELED) {
+			if (requestCode == ConversationActivity.REQUEST_DECRYPT_PGP) {
+				// discard the message to prevent decryption being blocked
+				conversation.getAccount().getPgpDecryptionService().giveUpCurrentDecryption();
+			}
 		}
 	}
 


### PR DESCRIPTION
When receiving a PGP message which is not encrypted with YOUR key,
OpenKeychain shows a dialog, which tells you the private key to decrypt
the message is unavailable. However, Conversations won't give up
decrypting the message. So whether the subsequent messages are
decryptable or not, the decryption is blocked at the current message.

The commit fixes the bug in this way: Give up the current message when
the decryption intent is cancelled, so that subsequent messages can be
handled.