### PR TITLE
Add help subtext to unverified contact keys

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
@@ -480,7 +480,7 @@ public class ContactDetailsActivity extends OmemoActivity implements OnAccountUp
 				}
 				if (!trust.isCompromised()) {
 					boolean highlight = session.getFingerprint().equals(messageFingerprint);
-					addFingerprintRow(keys, session, highlight);
+					addFingerprintRow(keys, session, highlight, false);
 				}
 			}
 			if (showsInactive || skippedInactive) {

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -1017,7 +1017,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 			for(XmppAxolotlSession session : mAccount.getAxolotlService().findOwnSessions()) {
 				if (!session.getTrust().isCompromised()) {
 					boolean highlight = session.getFingerprint().equals(messageFingerprint);
-					addFingerprintRow(keys,session,highlight);
+					addFingerprintRow(keys,session,highlight, true);
 					hasKeys = true;
 				}
 			}

--- a/src/main/java/eu/siacs/conversations/ui/OmemoActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/OmemoActivity.java
@@ -108,7 +108,7 @@ public abstract class OmemoActivity extends XmppActivity {
         }
     }
 
-    protected void addFingerprintRow(LinearLayout keys, final XmppAxolotlSession session, boolean highlight) {
+    protected void addFingerprintRow(LinearLayout keys, final XmppAxolotlSession session, boolean highlight, boolean ownKey) {
         final Account account = session.getAccount();
         final String fingerprint = session.getFingerprint();
         addFingerprintRowWithListeners(keys,
@@ -118,6 +118,7 @@ public abstract class OmemoActivity extends XmppActivity {
                 session.getTrust(),
                 true,
                 true,
+                ownKey,
                 new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -132,6 +133,7 @@ public abstract class OmemoActivity extends XmppActivity {
                                                      FingerprintStatus status,
                                                      boolean showTag,
                                                      boolean undecidedNeedEnablement,
+                                                     boolean ownKey,
                                                      CompoundButton.OnCheckedChangeListener
                                                              onCheckedChangeListener) {
         View view = getLayoutInflater().inflate(R.layout.contact_key, keys, false);
@@ -230,9 +232,18 @@ public abstract class OmemoActivity extends XmppActivity {
         }
         if (highlight) {
             keyType.setTextColor(ContextCompat.getColor(this, R.color.accent));
-            keyType.setText(getString(x509 ? R.string.omemo_fingerprint_x509_selected_message : R.string.omemo_fingerprint_selected_message));
+            if (status.isVerified() || ownKey) {
+                keyType.setText(getString(x509 ? R.string.omemo_fingerprint_x509_selected_message : R.string.omemo_fingerprint_selected_message));
+            } else {
+                keyType.setText(getString(x509 ? R.string.omemo_fingerprint_x509_selected_message_verify : R.string.omemo_fingerprint_selected_message_verify));
+            }
+
         } else {
-            keyType.setText(getString(x509 ? R.string.omemo_fingerprint_x509 : R.string.omemo_fingerprint));
+            if (status.isVerified() || ownKey ) {
+                keyType.setText(getString(x509 ? R.string.omemo_fingerprint_x509 : R.string.omemo_fingerprint));
+            } else {
+                keyType.setText(getString(x509 ? R.string.omemo_fingerprint_x509_verify : R.string.omemo_fingerprint_verify));
+            }
         }
 
         key.setText(CryptoHelper.prettifyFingerprint(fingerprint.substring(2)));

--- a/src/main/java/eu/siacs/conversations/ui/TrustKeysActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/TrustKeysActivity.java
@@ -193,7 +193,7 @@ public class TrustKeysActivity extends OmemoActivity implements OnKeyStatusUpdat
 		for(final String fingerprint : ownKeysToTrust.keySet()) {
 			hasOwnKeys = true;
 			addFingerprintRowWithListeners(ownKeys, mAccount, fingerprint, false,
-					FingerprintStatus.createActive(ownKeysToTrust.get(fingerprint)), false, false,
+					FingerprintStatus.createActive(ownKeysToTrust.get(fingerprint)), false, false, true,
 					new CompoundButton.OnCheckedChangeListener() {
 						@Override
 						public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -222,7 +222,7 @@ public class TrustKeysActivity extends OmemoActivity implements OnKeyStatusUpdat
 				final Map<String, Boolean> fingerprints = entry.getValue();
 				for (final String fingerprint : fingerprints.keySet()) {
 					addFingerprintRowWithListeners(keysContainer, mAccount, fingerprint, false,
-							FingerprintStatus.createActive(fingerprints.get(fingerprint)), false, false,
+							FingerprintStatus.createActive(fingerprints.get(fingerprint)), false, false, false,
 							new CompoundButton.OnCheckedChangeListener() {
 								@Override
 								public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {

--- a/src/main/res/menu/omemo_key_context.xml
+++ b/src/main/res/menu/omemo_key_context.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/verify_scan"
-        android:title="@string/scan_qr_code"
+        android:title="@string/scan_qr_code_verify"
         />
     <item
         android:id="@+id/distrust_key"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -228,9 +228,13 @@
 	<string name="otr_fingerprint_selected_message">OTR fingerprint of message</string>
 	<string name="openpgp_key_id">OpenPGP Key ID</string>
 	<string name="omemo_fingerprint">OMEMO fingerprint</string>
+	<string name="omemo_fingerprint_verify">OMEMO fingerprint (long press to verify)</string>
 	<string name="omemo_fingerprint_x509">v\\OMEMO fingerprint</string>
+	<string name="omemo_fingerprint_x509_verify">v\\OMEMO fingerprint (long press to verify)</string>
 	<string name="omemo_fingerprint_selected_message">OMEMO fingerprint of message</string>
+	<string name="omemo_fingerprint_selected_message_verify">OMEMO fingerprint of message (long press to verify)</string>
 	<string name="omemo_fingerprint_x509_selected_message">v\\OMEMO fingerprint of message</string>
+	<string name="omemo_fingerprint_x509_selected_message_verify">v\\OMEMO fingerprint of message (long press to verify)</string>
 	<string name="other_devices">Other devices</string>
 	<string name="trust_omemo_fingerprints">Trust OMEMO Fingerprints</string>
 	<string name="fetching_keys">Fetching keys…</string>
@@ -375,7 +379,8 @@
 	<string name="url_copied_to_clipboard">URL copied to clipboard</string>
 	<string name="message_copied_to_clipboard">Message copied to clipboard</string>
 	<string name="image_transmission_failed">Image transmission failed</string>
-	<string name="scan_qr_code">Scan 2D Barcode</string>
+	<string name="scan_qr_code">Scan 2D barcode</string>
+	<string name="scan_qr_code_verify">Scan 2D barcode to verify</string>
 	<string name="show_qr_code">Show 2D Barcode</string>
 	<string name="show_block_list">Show block list</string>
 	<string name="account_details">Account details</string>
@@ -760,6 +765,6 @@
 	<string name="pref_validate_hostname">Validate hostname with DNSSEC</string>
 	<string name="pref_validate_hostname_summary">Server certificates that contain the validated hostname are considered verified</string>
 	<string name="network_is_unreachable">Network is unreachable</string>
-    <string name="certificate_does_not_contain_jid">Certificate does not contain a Jabber ID</string>
-    <string name="server_info_partial">partial</string>
+	<string name="certificate_does_not_contain_jid">Certificate does not contain a Jabber ID</string>
+	<string name="server_info_partial">partial</string>
 </resources>


### PR DESCRIPTION
Tackling #2166 a bit, [this bit](https://github.com/siacs/Conversations/issues/2166#issuecomment-325290666) exactly.

![see1](https://i.imgur.com/JFWRYqe.png)

![see2](https://i.imgur.com/D9rmax7.png)

Since you seem to reuse the same view for keys, I didn't find another way to distinguish what key is actually presented (account or contact?) hence the extra variable, albeit I'm pretty sure you can write this better anyway. :)

Also not sure about `Scan 2D Barcode` should `B` be uppercase or lowercase? Lowercase looks better imho.

/PS: I'll have to rework #2622 once this is merged.

/LE: s/did/didn't/