### PR TITLE
Make usage of bundled emoji optional

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationActivity.java
@@ -182,7 +182,7 @@ public class ConversationActivity extends XmppActivity
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		new EmojiService(this).init();
+		new EmojiService(this).init(useBundledEmoji());
 		if (savedInstanceState != null) {
 			mOpenConversation = savedInstanceState.getString(STATE_OPEN_CONVERSATION, null);
 			mPanelOpen = savedInstanceState.getBoolean(STATE_PANEL_OPEN, true);
@@ -1759,6 +1759,10 @@ public class ConversationActivity extends XmppActivity
 
 	public boolean useGreenBackground() {
 		return getPreferences().getBoolean("use_green_background",getResources().getBoolean(R.bool.use_green_background));
+	}
+
+	public boolean useBundledEmoji() {
+		return getPreferences().getBoolean("use_bundled_emoji",getResources().getBoolean(R.bool.use_bundled_emoji));
 	}
 
 	protected boolean trustKeysIfNeeded(int requestCode) {

--- a/src/main/java/eu/siacs/conversations/ui/ShareWithActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ShareWithActivity.java
@@ -167,7 +167,8 @@ public class ShareWithActivity extends XmppActivity implements XmppConnectionSer
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		new EmojiService(this).init();
+		boolean useBundledEmoji = getPreferences().getBoolean("use_bundled_emoji",getResources().getBoolean(R.bool.use_bundled_emoji));
+		new EmojiService(this).init(useBundledEmoji);
 		if (getActionBar() != null) {
 			getActionBar().setDisplayHomeAsUpEnabled(false);
 			getActionBar().setHomeButtonEnabled(false);

--- a/src/main/java/eu/siacs/conversations/ui/service/AbstractEmojiService.java
+++ b/src/main/java/eu/siacs/conversations/ui/service/AbstractEmojiService.java
@@ -13,9 +13,9 @@ public abstract class AbstractEmojiService {
 
 	protected abstract EmojiCompat.Config buildConfig();
 
-	public void init() {
+	public void init(boolean useBundledEmoji) {
 		final EmojiCompat.Config config = buildConfig();
-		config.setReplaceAll(true);
+		config.setReplaceAll(useBundledEmoji);
 		EmojiCompat.init(config);
 	}
 }

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -357,6 +357,8 @@
   <string name="are_you_sure_verify_fingerprint">Bist du sicher, dass du den OTR-Fingerabdruck des Kontakts überprüfen willst?</string>
   <string name="pref_show_dynamic_tags">Dynamische Tags anzeigen</string>
   <string name="pref_show_dynamic_tags_summary">Schreibgeschütze Tags unterhalb der Kontakte anzeigen</string>
+  <string name="pref_use_bundled_emoji">Verwende mitgelieferte Emoji</string>
+  <string name="pref_use_bundled_emoji_summary">Nutze die mitgelieferten Emoji statt die des Systems</string>
   <string name="enable_notifications">Benachrichtigungen aktivieren</string>
   <string name="no_conference_server_found">Keinen Gruppenchatserver gefunden</string>
   <string name="conference_creation_failed">Erstellen des Gruppenchats fehlgeschlagen!</string>

--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -26,6 +26,7 @@
     <bool name="send_button_status">false</bool>
     <string name="quick_action">recent</string>
     <bool name="show_dynamic_tags">false</bool>
+    <bool name="use_bundled_emoji">true</bool>
     <bool name="btbv">true</bool>
     <integer name="automatic_message_deletion">0</integer>
     <bool name="dont_trust_system_cas">false</bool>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -391,6 +391,8 @@
 	<string name="are_you_sure_verify_fingerprint">Are you sure that you want to verify your contact’s OTR fingerprint?</string>
 	<string name="pref_show_dynamic_tags">Show dynamic tags</string>
 	<string name="pref_show_dynamic_tags_summary">Display read-only tags underneath contacts</string>
+	<string name="pref_use_bundled_emoji">Use bundled emoji</string>
+	<string name="pref_use_bundled_emoji_summary">Use bundled emoji instead of system ones</string>
 	<string name="enable_notifications">Enable notifications</string>
 	<string name="no_conference_server_found">No group chat server found</string>
 	<string name="conference_creation_failed">Group chat creation failed!</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -34,7 +34,7 @@
             android:key="last_activity"
             android:title="@string/pref_broadcast_last_activity"
             android:summary="@string/pref_broadcast_last_activity_summary"/>
-        </PreferenceCategory>
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_notification_settings">
         <CheckBoxPreference
             android:defaultValue="@bool/show_notification"
@@ -167,6 +167,11 @@
             android:key="show_dynamic_tags"
             android:summary="@string/pref_show_dynamic_tags_summary"
             android:title="@string/pref_show_dynamic_tags"/>
+        <CheckBoxPreference
+            android:defaultValue="@bool/use_bundled_emoji"
+            android:key="use_bundled_emoji"
+            android:summary="@string/pref_use_bundled_emoji_summary"
+            android:title="@string/pref_use_bundled_emoji"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:key="advanced"


### PR DESCRIPTION
This adds the options in the settings to default to the system emoji instead of always using the bundled emoji set. Default of setting is set to true so it always uses the bundled emoji, if setting turned of it uses the system emoji where possible and only uses the bundled emoji as a fallback. Change of the setting requires a restart of the app.
Would solve the (closed) issue [#2709](https://github.com/siacs/Conversations/issues/2709).

![Settings screenshot](https://user-images.githubusercontent.com/5928062/33287358-bc155158-d3b8-11e7-847c-9115cf8c92a1.png)
