### PR TITLE
added preferences option to hide message text in notifications

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -90,6 +90,10 @@ public class NotificationService {
 		return mXmppConnectionService.getBooleanPreference("show_notification",R.bool.show_notification);
 	}
 
+	public boolean notificationContentVisible() {
+		return mXmppConnectionService.getBooleanPreference("show_notification_content",R.bool.show_notification_content);
+	}
+
 	private boolean notificationsFromStrangers() {
 		return mXmppConnectionService.getBooleanPreference("notifications_from_strangers",R.bool.notifications_from_strangers);
 	}
@@ -336,7 +340,7 @@ public class NotificationService {
 				conversation = messages.get(0).getConversation();
 				final String name = conversation.getName();
 				SpannableString styledString;
-				if (Config.HIDE_MESSAGE_TEXT_IN_NOTIFICATION) {
+				if (Config.HIDE_MESSAGE_TEXT_IN_NOTIFICATION || !notificationContentVisible()) {
 					int count = messages.size();
 					styledString = new SpannableString(name + ": " + mXmppConnectionService.getResources().getQuantityString(R.plurals.x_messages,count,count));
 					styledString.setSpan(new StyleSpan(Typeface.BOLD), 0, name.length(), 0);
@@ -377,7 +381,7 @@ public class NotificationService {
 			mBuilder.setLargeIcon(mXmppConnectionService.getAvatarService()
 					.get(conversation, getPixel(64)));
 			mBuilder.setContentTitle(conversation.getName());
-			if (Config.HIDE_MESSAGE_TEXT_IN_NOTIFICATION) {
+			if (Config.HIDE_MESSAGE_TEXT_IN_NOTIFICATION || !notificationContentVisible()) {
 				int count = messages.size();
 				mBuilder.setContentText(mXmppConnectionService.getResources().getQuantityString(R.plurals.x_messages,count,count));
 			} else {

--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -12,6 +12,7 @@
     <bool name="chat_states">false</bool>
     <bool name="last_activity">false</bool>
     <bool name="show_notification">true</bool>
+    <bool name="show_notification_content">true</bool>
     <bool name="vibrate_on_notification">true</bool>
     <bool name="led">true</bool>
     <bool name="enable_quiet_hours">false</bool>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -111,6 +111,8 @@
 	<string name="pref_notification_settings">Notification</string>
 	<string name="pref_notifications">Notifications</string>
 	<string name="pref_notifications_summary">Notify when a new message arrives</string>
+	<string name="pref_notification_content">Show notification content</string>
+	<string name="pref_notification_content_summary">Show the message content in notification</string>
 	<string name="pref_vibrate">Vibrate</string>
 	<string name="pref_vibrate_summary">Vibrate when a new message arrives</string>
 	<string name="pref_led">LED Notification</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -42,6 +42,11 @@
             android:summary="@string/pref_notifications_summary"
             android:title="@string/pref_notifications"/>
         <CheckBoxPreference
+            android:defaultValue="@bool/show_notification_content"
+            android:key="show_notification_content"
+            android:summary="@string/pref_notification_content_summary"
+            android:title="@string/pref_notification_content"/>
+        <CheckBoxPreference
             android:defaultValue="@bool/notifications_from_strangers"
             android:key="notifications_from_strangers"
             android:dependency="show_notification"


### PR DESCRIPTION
An option has been added to the preferences which allows to decide whether the message content is displayed in the notifications or not. This allows the user to choose a higher privacy level since the message content in the notification can be read by anyone with physical access to the locked device.