### PR TITLE
setting room subject also sets room name

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -2615,9 +2615,10 @@ public class XmppConnectionService extends Service {
 		this.sendMessagePacket(conference.getAccount(), packet);
 		final MucOptions mucOptions = conference.getMucOptions();
 		final MucOptions.User self = mucOptions.getSelf();
-		if (!mucOptions.persistent() && self.getAffiliation().ranks(MucOptions.Affiliation.OWNER)) {
+		if (self.getAffiliation().ranks(MucOptions.Affiliation.OWNER)) {
 			Bundle options = new Bundle();
 			options.putString("muc#roomconfig_persistentroom", "1");
+			options.putString("muc#roomconfig_roomname", subject);
 			this.pushConferenceConfiguration(conference, options, null);
 		}
 	}


### PR DESCRIPTION
Some clients show the room's name more prominent than the subject. I'd like to improve compatibilty/useability with such clients (e.g. converse.js). I sugest that Conversations also sets the room name identical to the room subject. 