### PR TITLE
add scroll to bottom feature and display unread messages count

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -917,7 +917,7 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
 		}
 		int count = 0;
 		for (int i = messages.size() - 1; i >= 0; i--) {
-			if (Objects.equals(messages.get(i).getUuid(), uuid)) {
+			if (uuid.equals(messages.get(i).getUuid())) {
 				return count;
 			}
 			if (messages.get(i).getStatus() <= Message.STATUS_RECEIVED) {
@@ -926,7 +926,7 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
 		}
 		return 0;
 	}
-		
+
 	public interface OnMessageFound {
 		void onMessageFound(final Message message);
 	}

--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -17,7 +17,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import eu.siacs.conversations.Config;
@@ -916,12 +915,15 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
 			return  0;
 		}
 		int count = 0;
-		for (int i = messages.size() - 1; i >= 0; i--) {
-			if (uuid.equals(messages.get(i).getUuid())) {
-				return count;
-			}
-			if (messages.get(i).getStatus() <= Message.STATUS_RECEIVED) {
-				count = count + 1;
+		synchronized (this.messages) {
+			for (int i = messages.size() - 1; i >= 0; i--) {
+				final Message message = messages.get(i);
+				if (uuid.equals(message.getUuid())) {
+					return count;
+				}
+				if (message.getStatus() <= Message.STATUS_RECEIVED) {
+					++count;
+				}
 			}
 		}
 		return 0;

--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import eu.siacs.conversations.Config;
@@ -910,6 +911,22 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
 				&& sentMessagesCount() == 0;
 	}
 
+	public int getReceivedMessagesCountSinceUuid(String uuid) {
+		if (uuid == null) {
+			return  0;
+		}
+		int count = 0;
+		for (int i = messages.size() - 1; i >= 0; i--) {
+			if (Objects.equals(messages.get(i).getUuid(), uuid)) {
+				return count;
+			}
+			if (messages.get(i).getStatus() <= Message.STATUS_RECEIVED) {
+				count = count + 1;
+			}
+		}
+		return 0;
+	}
+		
 	public interface OnMessageFound {
 		void onMessageFound(final Message message);
 	}

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -201,9 +201,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 				}
 			} else {
 				lastMessageUuid = null;
-				binding.scrollToBottomButton.setEnabled(false);
-				binding.scrollToBottomButton.setVisibility(View.GONE);
-				binding.unreadCountCustomView.setVisibility(View.GONE);
+				hideUnreadMessagesCount();
 			}
 		}
 

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -380,12 +380,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
  		@Override
  		public void onClick(View v) {
 			binding.messagesView.setSelection(binding.messagesView.getCount() - 1);
-			binding.messagesView.post(new Runnable() {
-				@Override
- 				public void run() {
-					mOnScrollListener.onScrollStateChanged(binding.messagesView, 0);
-				}
- 			});
+			binding.messagesView.post(() -> mOnScrollListener.onScrollStateChanged(binding.messagesView, 0));
 		}
  	};
 	private OnClickListener mSendButtonListener = new OnClickListener() {
@@ -2525,11 +2520,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 			if (lastMessageUuid != null) {
 				this.lastMessageUuid = lastMessageUuid;
 				binding.unreadCountCustomView.setUnreadCount(conversation.getReceivedMessagesCountSinceUuid(lastMessageUuid));
-				binding.messagesView.post(new Runnable() {
-					public void run() {
-						mOnScrollListener.onScrollStateChanged(binding.messagesView, 0);
-					}
-				});
+				binding.messagesView.post(() -> mOnScrollListener.onScrollStateChanged(binding.messagesView, 0));
 			}
 		}
 		ActivityResult activityResult = postponedActivityResult.pop();

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -128,14 +128,16 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 	public static final String STATE_CONVERSATION_UUID = ConversationFragment.class.getName() + ".uuid";
 	public static final String STATE_SCROLL_POSITION = ConversationFragment.class.getName() + ".scroll_position";
 	public static final String STATE_PHOTO_URI = ConversationFragment.class.getName() + ".take_photo_uri";
-
+	private static final String STATE_LAST_MESSAGE_UUID = "state_last_message_uuid";
 
 	final protected List<Message> messageList = new ArrayList<>();
+	private String lastMessageUuid = null;
 	private final PendingItem<ActivityResult> postponedActivityResult = new PendingItem<>();
 	private final PendingItem<String> pendingConversationsUuid = new PendingItem<>();
 	private final PendingItem<Bundle> pendingExtras = new PendingItem<>();
 	private final PendingItem<Uri> pendingTakePhotoUri = new PendingItem<>();
 	private final PendingItem<ScrollState> pendingScrollState = new PendingItem<>();
+	private final PendingItem<String> pendingLastMessageUuid = new PendingItem<>();
 	private final PendingItem<Message> pendingMessage = new PendingItem<>();
 	public Uri mPendingEditorContent = null;
 	protected MessageAdapter messageListAdapter;
@@ -188,8 +190,21 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 
 		@Override
 		public void onScrollStateChanged(AbsListView view, int scrollState) {
-			// TODO Auto-generated method stub
-
+			if (binding.messagesView.getLastVisiblePosition() < binding.messagesView.getCount() - 5) {
+				binding.scrollToBottomButton.setEnabled(true);
+				binding.scrollToBottomButton.setVisibility(View.VISIBLE);
+				if (lastMessageUuid == null) {
+					lastMessageUuid = conversation.getLatestMessage().getUuid();
+				}
+				if (conversation.getReceivedMessagesCountSinceUuid(lastMessageUuid) > 0) {
+					binding.unreadCountCustomView.setVisibility(View.VISIBLE);
+				}
+			} else {
+				lastMessageUuid = null;
+				binding.scrollToBottomButton.setEnabled(false);
+				binding.scrollToBottomButton.setVisibility(View.GONE);
+				binding.unreadCountCustomView.setVisibility(View.GONE);
+			}
 		}
 
 		@Override
@@ -362,6 +377,19 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 			return false;
 		}
 	};
+	private OnClickListener mScrollButtonListener = new OnClickListener() {
+
+ 		@Override
+ 		public void onClick(View v) {
+			binding.messagesView.setSelection(binding.messagesView.getCount() - 1);
+			binding.messagesView.post(new Runnable() {
+				@Override
+ 				public void run() {
+					mOnScrollListener.onScrollStateChanged(binding.messagesView, 0);
+				}
+ 			});
+		}
+ 	};
 	private OnClickListener mSendButtonListener = new OnClickListener() {
 
 		@Override
@@ -869,6 +897,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 
 		binding.textSendButton.setOnClickListener(this.mSendButtonListener);
 
+		binding.scrollToBottomButton.setOnClickListener(this.mScrollButtonListener);
 		binding.messagesView.setOnScrollListener(mOnScrollListener);
 		binding.messagesView.setTranscriptMode(ListView.TRANSCRIPT_MODE_NORMAL);
 		messageListAdapter = new MessageAdapter((XmppActivity) getActivity(), this.messageList);
@@ -1691,6 +1720,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 		super.onSaveInstanceState(outState);
 		if (conversation != null) {
 			outState.putString(STATE_CONVERSATION_UUID, conversation.getUuid());
+			outState.putString(STATE_LAST_MESSAGE_UUID, lastMessageUuid);
 			final Uri uri = pendingTakePhotoUri.peek();
 			if (uri != null) {
 				outState.putString(STATE_PHOTO_URI, uri.toString());
@@ -1709,6 +1739,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 			return;
 		}
 		String uuid = savedInstanceState.getString(STATE_CONVERSATION_UUID);
+		pendingLastMessageUuid.push(savedInstanceState.getString(STATE_LAST_MESSAGE_UUID, null));
 		if (uuid != null) {
 			this.pendingConversationsUuid.push(uuid);
 			String takePhotoUri = savedInstanceState.getString(STATE_PHOTO_URI);
@@ -1819,6 +1850,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 		this.binding.textinput.setKeyboardListener(this);
 		messageListAdapter.updatePreferences();
 		refresh(false);
+		updateUnreadMessagesCount();
 		this.conversation.messagesLoaded.set(true);
 
 		Log.d(Config.LOGTAG, "scrolledToBottomAndNoPending=" + Boolean.toString(scrolledToBottomAndNoPending));
@@ -1843,6 +1875,17 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 		//TODO if we only do this when this fragment is running on main it won't *bing* in tablet layout which might be unnecessary since we can *see* it
 		activity.xmppConnectionService.getNotificationService().setOpenConversation(this.conversation);
 		return true;
+	}
+
+	private void updateUnreadMessagesCount() {
+		lastMessageUuid = null;
+		hideUnreadMessagesCount();
+	}
+
+	private void hideUnreadMessagesCount() {
+		binding.scrollToBottomButton.setEnabled(false);
+		binding.scrollToBottomButton.setVisibility(View.GONE);
+		binding.unreadCountCustomView.setVisibility(View.GONE);
 	}
 
 	private void setSelection(int pos) {
@@ -2001,6 +2044,10 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 				conversation.populateWithMessages(this.messageList);
 				updateSnackBar(conversation);
 				updateStatusMessages();
+				if (conversation.getReceivedMessagesCountSinceUuid(lastMessageUuid) != 0) {
+					binding.unreadCountCustomView.setVisibility(View.VISIBLE);
+					binding.unreadCountCustomView.setUnreadCount(conversation.getReceivedMessagesCountSinceUuid(lastMessageUuid));
+				}
 				this.messageListAdapter.notifyDataSetChanged();
 				updateChatMsgHint();
 				if (notifyConversationRead && activity != null) {
@@ -2029,6 +2076,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 			new Handler().post(() -> {
 				int size = messageList.size();
 				this.binding.messagesView.setSelection(size - 1);
+				binding.messagesView.post(() -> mOnScrollListener.onScrollStateChanged(binding.messagesView, 0));
 			});
 		}
 	}
@@ -2472,6 +2520,16 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 			ScrollState scrollState = pendingScrollState.pop();
 			if (scrollState != null) {
 				setScrollPosition(scrollState);
+			}
+			String lastMessageUuid = pendingLastMessageUuid.pop();
+			if (lastMessageUuid != null) {
+				this.lastMessageUuid = lastMessageUuid;
+				binding.unreadCountCustomView.setUnreadCount(conversation.getReceivedMessagesCountSinceUuid(lastMessageUuid));
+				binding.messagesView.post(new Runnable() {
+					public void run() {
+						mOnScrollListener.onScrollStateChanged(binding.messagesView, 0);
+					}
+				});
 			}
 		}
 		ActivityResult activityResult = postponedActivityResult.pop();

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -1816,6 +1816,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 			this.reInitRequiredOnStart = true;
 			pendingExtras.push(extras);
 		}
+		updateUnreadMessagesCount();
 	}
 
 	private void reInit(Conversation conversation) {
@@ -1850,9 +1851,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 		this.binding.textinput.setKeyboardListener(this);
 		messageListAdapter.updatePreferences();
 		refresh(false);
-		updateUnreadMessagesCount();
 		this.conversation.messagesLoaded.set(true);
-
 		Log.d(Config.LOGTAG, "scrolledToBottomAndNoPending=" + Boolean.toString(scrolledToBottomAndNoPending));
 
 		if (hasExtras || scrolledToBottomAndNoPending) {
@@ -1883,9 +1882,12 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 	}
 
 	private void hideUnreadMessagesCount() {
-		binding.scrollToBottomButton.setEnabled(false);
-		binding.scrollToBottomButton.setVisibility(View.GONE);
-		binding.unreadCountCustomView.setVisibility(View.GONE);
+		if (this.binding == null) {
+			return;
+		}
+		this.binding.scrollToBottomButton.setEnabled(false);
+		this.binding.scrollToBottomButton.setVisibility(View.GONE);
+		this.binding.unreadCountCustomView.setVisibility(View.GONE);
 	}
 
 	private void setSelection(int pos) {

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -13,6 +13,7 @@ import android.provider.MediaStore;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.app.Fragment;
 import android.app.PendingIntent;
@@ -1746,6 +1747,9 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 	@Override
 	public void onStart() {
 		super.onStart();
+		XmppActivity activity = (XmppActivity) getActivity();
+		binding.scrollToBottomButton.setBackgroundTintList(ContextCompat.getColorStateList
+				(activity, activity.getThemeResource(R.attr.color_background_primary, R.color.white)));
 		if (this.reInitRequiredOnStart) {
 			final Bundle extras = pendingExtras.pop();
 			reInit(conversation, extras != null);

--- a/src/main/res/drawable/ic_scroll_to_end.xml
+++ b/src/main/res/drawable/ic_scroll_to_end.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#939192" android:pathData="M16.59,5.59L18,7L12,13L6,7L7.41,5.59L12,10.17L16.59,5.59M16.59,11.59L18,13L12,19L6,13L7.41,11.59L12,16.17L16.59,11.59Z" />
+</vector>

--- a/src/main/res/layout/fragment_conversation.xml
+++ b/src/main/res/layout/fragment_conversation.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <RelativeLayout
         xmlns:tools="http://schemas.android.com/tools"
@@ -22,6 +23,29 @@
             android:transcriptMode="normal"
             tools:listitem="@layout/message_sent">
         </ListView>
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/scroll_to_bottom_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:layout_alignParentEnd="true"
+            android:layout_alignBottom="@+id/messages_view"
+            android:alpha="0.85"
+            app:backgroundTint="@color/white"
+            android:src="@drawable/ic_scroll_to_end"
+            app:fabSize="mini"
+            android:visibility="gone"/>
+
+        <eu.siacs.conversations.ui.widget.UnreadCountCustomView
+            android:id="@+id/unread_count_custom_view"
+            android:layout_width="?attr/IconSize"
+            android:layout_height="?attr/IconSize"
+            android:layout_alignTop="@+id/scroll_to_bottom_button"
+            android:layout_alignEnd="@+id/scroll_to_bottom_button"
+            android:elevation="8dp"
+            android:visibility="gone"
+            app:backgroundColor="?attr/unread_count" />
 
         <RelativeLayout
             android:id="@+id/textsend"

--- a/src/main/res/layout/fragment_conversation.xml
+++ b/src/main/res/layout/fragment_conversation.xml
@@ -45,7 +45,8 @@
             android:layout_alignEnd="@+id/scroll_to_bottom_button"
             android:elevation="8dp"
             android:visibility="gone"
-            app:backgroundColor="?attr/unread_count" />
+            app:backgroundColor="?attr/unread_count"
+            style="@style/TextAppearance.Conversations.Body1.Secondary"/>
 
         <RelativeLayout
             android:id="@+id/textsend"


### PR DESCRIPTION
This pull request solves issue #2568. It adds the feature to scroll to bottom when the user is viewing the message history. Also, it displays the unread message count on the fab if the user is above in his message history.