### PR TITLE
Fix the French translation for the add_back string

### DIFF
--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -244,7 +244,7 @@
   <string name="joining_conference">Rejoindre la conversation de groupe</string>
   <string name="leave">Partir</string>
   <string name="contact_added_you">Votre correspondant vous a ajouté dans sa liste de contacts</string>
-  <string name="add_back">Ré-ajouter</string>
+  <string name="add_back">Ajouter en retour</string>
   <string name="contact_has_read_up_to_this_point">%s a tout lu jusqu\'ici</string>
   <string name="contacts_have_read_up_to_this_point">%s a tout lu jusqu\'ici</string>
   <string name="contacts_and_n_more_have_read_up_to_this_point">%1$s+%2$d et plus  ont tout lu jusqu\'ici</string>


### PR DESCRIPTION
It was translated to something like “add again”, which doesn’t carry the same meaning and can be confusing for users.

It would be useful to also check how it has been translated in other languages, and add a source comment for future translators.

This is related to #2778.