### PR TITLE
Fixes #2786 : Certificate dialogue not respecting dark theme solved

### DIFF
--- a/libs/MemorizingTrustManager/res/values-v21/themes.xml
+++ b/libs/MemorizingTrustManager/res/values-v21/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ConversationsTheme" parent="@android:style/Theme.Material.Light.DarkActionBar" />
+    <style name="ConversationsTheme.Dark" parent="android:Theme.Material" />
+
+</resources>

--- a/libs/MemorizingTrustManager/res/values/defaults.xml
+++ b/libs/MemorizingTrustManager/res/values/defaults.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="theme">light</string>
+</resources>

--- a/libs/MemorizingTrustManager/res/values/themes.xml
+++ b/libs/MemorizingTrustManager/res/values/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ConversationsTheme" parent="@android:style/Theme.Holo.Light.DarkActionBar" />
+    <style name="ConversationsTheme.Dark" parent="@android:style/Theme.Holo" />
+
+</resources>

--- a/libs/MemorizingTrustManager/src/de/duenndns/ssl/MemorizingActivity.java
+++ b/libs/MemorizingTrustManager/src/de/duenndns/ssl/MemorizingActivity.java
@@ -24,20 +24,24 @@
 package de.duenndns.ssl;
 
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
-import android.content.DialogInterface.*;
+import android.content.DialogInterface.OnCancelListener;
+import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class MemorizingActivity extends Activity
 		implements OnClickListener,OnCancelListener {
 
 	private final static Logger LOGGER = Logger.getLogger(MemorizingActivity.class.getName());
+	public static final String THEME = "theme";
 
 	int decisionId;
 
@@ -46,6 +50,7 @@ public class MemorizingActivity extends Activity
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		LOGGER.log(Level.FINE, "onCreate");
+		setTheme(findTheme());
 		super.onCreate(savedInstanceState);
 	}
 
@@ -78,6 +83,15 @@ public class MemorizingActivity extends Activity
 		LOGGER.log(Level.FINE, "Sending decision: " + decision);
 		MemorizingTrustManager.interactResult(decisionId, decision);
 		finish();
+	}
+
+	protected int findTheme() {
+		return getPreferences().getString(THEME, getResources().getString(R.string.theme)).equals("dark") ? R.style.ConversationsTheme_Dark : R.style.ConversationsTheme;
+	}
+
+	protected SharedPreferences getPreferences() {
+		return PreferenceManager
+				.getDefaultSharedPreferences(getApplicationContext());
 	}
 
 	// react on AlertDialog button press


### PR DESCRIPTION
# Before:

Both, in dark theme and light theme, the Certificate dialogue was in light theme.

![screenshot_2018-02-14-05-48-45](https://user-images.githubusercontent.com/16588032/36181719-0def483c-114c-11e8-98ba-1cc96117fe04.png)

# After

In dark theme:

![screenshot_2018-02-14-05-49-15](https://user-images.githubusercontent.com/16588032/36181767-4250de24-114c-11e8-9050-134f2705aea3.png)

In light theme:

![screenshot_2018-02-14-05-48-45](https://user-images.githubusercontent.com/16588032/36181779-51bdec58-114c-11e8-9977-8ce94e9db276.png)

