### PR TITLE
show start orbot dialog

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
@@ -136,7 +136,7 @@ public class ConversationsActivity extends XmppActivity implements OnConversatio
 			if (!TorServiceUtils.isOrbotInstalled(this)) {
 				showDialogIfNecessary(DOWNLOAD_ORBOT_PREF_TITLE, DOWNLOAD_ORBOT_PREF_LAST_TIME, false);
 			} else {
-				if (!TorServiceUtils.isOrbotStarted()) {
+				if (xmppConnectionService != null && !TorServiceUtils.isOrbotStarted(xmppConnectionService.getAccounts())) {
 					showDialogIfNecessary(START_ORBOT_PREF_TITLE, START_ORBOT_PREF_LAST_TIME, true);
 				}
 			}

--- a/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
@@ -92,7 +92,7 @@ public class ConversationsActivity extends XmppActivity implements OnConversatio
  	public static final String DOWNLOAD_ORBOT_PREF_TITLE = "download_orbot";
  	public static final String DOWNLOAD_ORBOT_PREF_LAST_TIME="download_dialog_last_shown";
  	private static final String ORBOT_DIALOG_TAG="DIALOG_ORBOT";
-	private static final int TIME_SINCE_PREV_DIALOG = 15;
+	private static final int TIME_SINCE_PREV_DIALOG = 25;
 
 	public static final int REQUEST_OPEN_MESSAGE = 0x9876;
 	public static final int REQUEST_PLAY_PAUSE = 0x5432;

--- a/src/main/java/eu/siacs/conversations/ui/DownloadOrbotDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/DownloadOrbotDialog.java
@@ -1,0 +1,73 @@
+package eu.siacs.conversations.ui;
+
+import android.app.Dialog;
+import android.support.annotation.NonNull;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.app.AlertDialog;
+
+import eu.siacs.conversations.R;
+import eu.siacs.conversations.utils.TorServiceUtils;
+
+public class DownloadOrbotDialog extends DialogFragment {
+
+    private static final String ARG_CANCELABLE = StartOrbotDialog.class.getCanonicalName() + ".ARG_CANCELABLE";
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setCancelable(false);
+    }
+
+    /**
+     * Public factory method to get dialog instances.
+     *
+     * @param cancelable If 'true', the dialog can be cancelled by the user input (BACK button, touch outside...)
+     * @return New dialog instance, ready to show.
+     */
+    public static DownloadOrbotDialog newInstance(boolean cancelable) {
+        DownloadOrbotDialog fragment = new DownloadOrbotDialog();
+        Bundle args = new Bundle();
+        args.putBoolean(ARG_CANCELABLE, cancelable);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        boolean cancelable = getArguments().getBoolean(ARG_CANCELABLE, false);
+        setCancelable(cancelable);
+
+        AlertDialog.Builder downloadDialog = new AlertDialog.Builder(getActivity());
+        downloadDialog.setTitle(R.string.install_orbot_dialog_title);
+        downloadDialog.setMessage(R.string.install_orbot_dialog_description);
+        downloadDialog.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialogInterface, int i) {
+                TorServiceUtils.downloadOrbot(getActivity());
+            }
+        });
+        downloadDialog.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialogInterface, int i) {
+            }
+        });
+
+        return downloadDialog.show();
+    }
+
+    @Override
+    public void onDestroyView() {
+        Dialog dialog = getDialog();
+        if (dialog != null && getRetainInstance()) {
+            dialog.setDismissMessage(null);
+        }
+        super.onDestroyView();
+    }
+}

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -127,7 +127,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 			final String password = mPassword.getText().toString();
 			final boolean wasDisabled = mAccount != null && mAccount.getStatus() == Account.State.DISABLED;
 
-			if (mInitMode && mUseTor && (!TorServiceUtils.isOrbotInstalled(EditAccountActivity.this) || !TorServiceUtils.isOrbotStarted())) {
+			if (mInitMode && mUseTor && (!TorServiceUtils.isOrbotInstalled(EditAccountActivity.this) || !(TorServiceUtils.isOrbotStarted(mAccount)))) {
 				if (!TorServiceUtils.isOrbotInstalled(EditAccountActivity.this)) {
 					TorServiceUtils.downloadOrbot(EditAccountActivity.this, REQUEST_DOWNLOAD_ORBOT);
 				} else {
@@ -436,7 +436,9 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 			}
 		}
 		if (requestCode == REQUEST_DOWNLOAD_ORBOT || requestCode == REQUEST_START_ORBOT) {
-			updateSaveButton();
+			if (mAccount != null) {
+				xmppConnectionService.updateAccount(mAccount);
+			}
 		}
 	}
 
@@ -497,7 +499,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 				} else if (mUseTor) {
 					if (!TorServiceUtils.isOrbotInstalled(this)) {
 						this.mSaveButton.setText(R.string.download_orbot);
-					} else if (!TorServiceUtils.isOrbotStarted()) {
+					} else if (!TorServiceUtils.isOrbotStarted(mAccount)) {
 						this.mSaveButton.setText(R.string.start_orbot);
 					} else {
 						this.mSaveButton.setText(R.string.next);
@@ -1109,6 +1111,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 					errorLayout = this.mAccountJidLayout;
 				}
 				errorLayout.setError(getString(this.mAccount.getStatus().getReadableId()));
+
 				if (init || !accountInfoEdited()) {
 					errorLayout.requestFocus();
 				}

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -81,6 +81,8 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 
 	private static final int REQUEST_DATA_SAVER = 0xf244;
 	private static final int REQUEST_CHANGE_STATUS = 0xee11;
+	private static final int REQUEST_DOWNLOAD_ORBOT = 0xee12;
+	private static final int REQUEST_START_ORBOT = 0xee13;
 	private TextInputLayout mAccountJidLayout;
 	private EditText mPassword;
 	private TextInputLayout mPasswordLayout;
@@ -127,9 +129,9 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 
 			if (mInitMode && mUseTor && (!TorServiceUtils.isOrbotInstalled(EditAccountActivity.this) || !TorServiceUtils.isOrbotStarted())) {
 				if (!TorServiceUtils.isOrbotInstalled(EditAccountActivity.this)) {
-					TorServiceUtils.downloadOrbot(EditAccountActivity.this);
+					TorServiceUtils.downloadOrbot(EditAccountActivity.this, REQUEST_DOWNLOAD_ORBOT);
 				} else {
-					TorServiceUtils.startOrbot(EditAccountActivity.this);
+					TorServiceUtils.startOrbot(EditAccountActivity.this, REQUEST_START_ORBOT);
 				}
 				return;
 			}
@@ -432,6 +434,9 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 			} else {
 				Log.d(Config.LOGTAG,"pgp result not ok");
 			}
+		}
+		if (requestCode == REQUEST_DOWNLOAD_ORBOT || requestCode == REQUEST_START_ORBOT) {
+			updateSaveButton();
 		}
 	}
 

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -3,7 +3,6 @@ package eu.siacs.conversations.ui;
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.SharedPreferences;
@@ -28,7 +27,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
-import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.EditText;
@@ -37,7 +35,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TableLayout;
-import android.widget.TableRow;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -67,6 +64,7 @@ import eu.siacs.conversations.ui.adapter.PresenceTemplateAdapter;
 import eu.siacs.conversations.ui.util.PendingItem;
 import eu.siacs.conversations.ui.widget.DisabledActionModeCallback;
 import eu.siacs.conversations.utils.CryptoHelper;
+import eu.siacs.conversations.utils.TorServiceUtils;
 import eu.siacs.conversations.utils.UIHelper;
 import eu.siacs.conversations.utils.XmppUri;
 import eu.siacs.conversations.xml.Element;
@@ -127,6 +125,14 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 			final String password = mPassword.getText().toString();
 			final boolean wasDisabled = mAccount != null && mAccount.getStatus() == Account.State.DISABLED;
 
+			if (mInitMode && mUseTor && (!TorServiceUtils.isOrbotInstalled(EditAccountActivity.this) || !TorServiceUtils.isOrbotStarted())) {
+				if (!TorServiceUtils.isOrbotInstalled(EditAccountActivity.this)) {
+					TorServiceUtils.downloadOrbot(EditAccountActivity.this);
+				} else {
+					TorServiceUtils.startOrbot(EditAccountActivity.this);
+				}
+				return;
+			}
 			if (!mInitMode && passwordChangedInMagicCreateMode()) {
 				gotoChangePassword(password);
 				return;
@@ -258,7 +264,6 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 				updateSaveButton();
 				updateAccountInformation(true);
 			}
-
 		}
 	};
 	private final OnClickListener mCancelButtonClickListener = new OnClickListener() {
@@ -484,6 +489,14 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 				URL url = connection != null && mAccount.getStatus() == Account.State.REGISTRATION_WEB ? connection.getRedirectionUrl() : null;
 				if (url != null && this.binding.accountRegisterNew.isChecked()) {
 					this.mSaveButton.setText(R.string.open_website);
+				} else if (mUseTor) {
+					if (!TorServiceUtils.isOrbotInstalled(this)) {
+						this.mSaveButton.setText(R.string.download_orbot);
+					} else if (!TorServiceUtils.isOrbotStarted()) {
+						this.mSaveButton.setText(R.string.start_orbot);
+					} else {
+						this.mSaveButton.setText(R.string.next);
+					}
 				} else {
 					this.mSaveButton.setText(R.string.next);
 				}

--- a/src/main/java/eu/siacs/conversations/ui/StartOrbotDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/StartOrbotDialog.java
@@ -1,0 +1,73 @@
+package eu.siacs.conversations.ui;
+
+import android.app.Dialog;
+import android.support.annotation.NonNull;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.app.AlertDialog;
+
+import eu.siacs.conversations.R;
+import eu.siacs.conversations.utils.TorServiceUtils;
+
+public class StartOrbotDialog extends DialogFragment {
+
+    private static final String ARG_CANCELABLE = StartOrbotDialog.class.getCanonicalName() + ".ARG_CANCELABLE";
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setCancelable(false);
+    }
+
+    /**
+     * Public factory method to get dialog instances.
+     *
+     * @param cancelable If 'true', the dialog can be cancelled by the user input (BACK button, touch outside...)
+     * @return New dialog instance, ready to show.
+     */
+    public static StartOrbotDialog newInstance(boolean cancelable) {
+        StartOrbotDialog fragment = new StartOrbotDialog();
+        Bundle args = new Bundle();
+        args.putBoolean(ARG_CANCELABLE, cancelable);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        boolean cancelable = getArguments().getBoolean(ARG_CANCELABLE, false);
+        setCancelable(cancelable);
+
+        AlertDialog.Builder startDialog = new AlertDialog.Builder(getActivity());
+        startDialog.setTitle(R.string.start_orbot_dialog_title);
+        startDialog.setMessage(R.string.start_orbot_dialog_description);
+        startDialog.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialogInterface, int i) {
+                TorServiceUtils.startOrbot(getActivity());
+            }
+        });
+        startDialog.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialogInterface, int i) {
+            }
+        });
+
+        return startDialog.show();
+    }
+
+    @Override
+    public void onDestroyView() {
+        Dialog dialog = getDialog();
+        if (dialog != null && getRetainInstance()) {
+            dialog.setDismissMessage(null);
+        }
+        super.onDestroyView();
+    }
+}

--- a/src/main/java/eu/siacs/conversations/utils/TorServiceUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/TorServiceUtils.java
@@ -1,0 +1,112 @@
+package eu.siacs.conversations.utils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.URLEncoder;
+import java.util.StringTokenizer;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.util.Log;
+
+public class TorServiceUtils {
+
+    private final static String TAG = "TorUtils";
+    private final static String URI_ORBOT = "org.torproject.android";
+    private final static String TOR_BIN_PATH = "/data/data/org.torproject.android/app_bin/tor";
+
+    private static final String ORBOT_PLAYSTORE_URI = "market://details?id=" + URI_ORBOT;
+    private final static String ACTION_START_TOR = "org.torproject.android.START_TOR";
+
+    private final static String SHELL_CMD_PS = "ps";
+    private final static String SHELL_CMD_PIDOF = "pidof";
+
+    private static int findOrbotProcessId() {
+        int procId = -1;
+        try {
+            procId = findProcessIdWithPidOf(TOR_BIN_PATH);
+            if (procId == -1)
+                procId = findProcessIdWithPS(TOR_BIN_PATH);
+        } catch (Exception e) {
+            try {
+                procId = findProcessIdWithPS(TOR_BIN_PATH);
+            } catch (Exception e2) {
+                Log.e(TAG, "Unable to get proc id for command: " + URLEncoder.encode(TOR_BIN_PATH), e2);
+            }
+        }
+        return procId;
+    }
+
+    private static int findProcessIdWithPidOf(String command) throws Exception {
+        int procId = -1;
+        Runtime r = Runtime.getRuntime();
+        String baseName = new File(command).getName();
+
+        Process procPs = r.exec(new String[]{
+                SHELL_CMD_PIDOF, baseName
+        });
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(procPs.getInputStream()));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            try {
+                procId = Integer.parseInt(line.trim());
+                break;
+            } catch (NumberFormatException e) {
+                Log.e("TorServiceUtils", "unable to parse process pid: " + line, e);
+            }
+        }
+        return procId;
+    }
+
+    private static int findProcessIdWithPS(String command) throws Exception {
+        int procId = -1;
+        Runtime r = Runtime.getRuntime();
+
+        Process procPs = r.exec(SHELL_CMD_PS);
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(procPs.getInputStream()));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            if (line.contains(' ' + command)) {
+                StringTokenizer st = new StringTokenizer(line, " ");
+                st.nextToken();
+                procId = Integer.parseInt(st.nextToken().trim());
+                break;
+            }
+        }
+        return procId;
+    }
+
+    public static boolean isOrbotInstalled(Context context) {
+        PackageManager pm = context.getPackageManager();
+        boolean installed;
+        try {
+            pm.getPackageInfo(URI_ORBOT, PackageManager.GET_ACTIVITIES);
+            installed = true;
+        } catch (PackageManager.NameNotFoundException e) {
+            installed = false;
+        }
+        return installed;
+    }
+
+    public static boolean isOrbotStarted() {
+        int procId = TorServiceUtils.findOrbotProcessId();
+        return (procId != -1);
+    }
+
+    public static void downloadOrbot(Context context) {
+        Uri uri = Uri.parse(ORBOT_PLAYSTORE_URI);
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        context.startActivity(intent);
+    }
+
+    public static void startOrbot(Context context) {
+        Intent launchIntent = new Intent(URI_ORBOT);
+        launchIntent.setAction(ACTION_START_TOR);
+        context.startActivity(launchIntent);
+    }
+}

--- a/src/main/java/eu/siacs/conversations/utils/TorServiceUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/TorServiceUtils.java
@@ -4,14 +4,18 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.net.URLEncoder;
+import java.util.List;
 import java.util.StringTokenizer;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.util.Log;
+
+import eu.siacs.conversations.entities.Account;
 
 public class TorServiceUtils {
 
@@ -94,9 +98,17 @@ public class TorServiceUtils {
         return installed;
     }
 
-    public static boolean isOrbotStarted() {
-        int procId = TorServiceUtils.findOrbotProcessId();
-        return (procId != -1);
+    public static boolean isOrbotStarted(Account account) {
+        return !(account != null && account.getStatus() == Account.State.TOR_NOT_AVAILABLE);
+    }
+
+    public static boolean isOrbotStarted(List<Account> accountList) {
+        for (Account account : accountList) {
+            if (!isOrbotStarted(account)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static void downloadOrbot(Context context) {
@@ -114,7 +126,11 @@ public class TorServiceUtils {
     public static void downloadOrbot(Activity activity, int requestCode) {
         Uri uri = Uri.parse(ORBOT_PLAYSTORE_URI);
         Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-        activity.startActivityForResult(intent, requestCode);
+        try {
+            activity.startActivityForResult(intent, requestCode);
+        } catch(ActivityNotFoundException e) {
+            e.printStackTrace();
+        }
     }
 
     public static void startOrbot(Activity activity, int requestCode) {

--- a/src/main/java/eu/siacs/conversations/utils/TorServiceUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/TorServiceUtils.java
@@ -6,6 +6,7 @@ import java.io.InputStreamReader;
 import java.net.URLEncoder;
 import java.util.StringTokenizer;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -108,5 +109,17 @@ public class TorServiceUtils {
         Intent launchIntent = new Intent(URI_ORBOT);
         launchIntent.setAction(ACTION_START_TOR);
         context.startActivity(launchIntent);
+    }
+
+    public static void downloadOrbot(Activity activity, int requestCode) {
+        Uri uri = Uri.parse(ORBOT_PLAYSTORE_URI);
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        activity.startActivityForResult(intent, requestCode);
+    }
+
+    public static void startOrbot(Activity activity, int requestCode) {
+        Intent launchIntent = new Intent(URI_ORBOT);
+        launchIntent.setAction(ACTION_START_TOR);
+        activity.startActivityForResult(launchIntent, requestCode);
     }
 }

--- a/src/main/java/eu/siacs/conversations/utils/TorServiceUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/TorServiceUtils.java
@@ -1,11 +1,6 @@
 package eu.siacs.conversations.utils;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStreamReader;
-import java.net.URLEncoder;
 import java.util.List;
-import java.util.StringTokenizer;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -13,78 +8,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.util.Log;
 
 import eu.siacs.conversations.entities.Account;
 
 public class TorServiceUtils {
 
-    private final static String TAG = "TorUtils";
     private final static String URI_ORBOT = "org.torproject.android";
-    private final static String TOR_BIN_PATH = "/data/data/org.torproject.android/app_bin/tor";
-
     private static final String ORBOT_PLAYSTORE_URI = "market://details?id=" + URI_ORBOT;
     private final static String ACTION_START_TOR = "org.torproject.android.START_TOR";
-
-    private final static String SHELL_CMD_PS = "ps";
-    private final static String SHELL_CMD_PIDOF = "pidof";
-
-    private static int findOrbotProcessId() {
-        int procId = -1;
-        try {
-            procId = findProcessIdWithPidOf(TOR_BIN_PATH);
-            if (procId == -1)
-                procId = findProcessIdWithPS(TOR_BIN_PATH);
-        } catch (Exception e) {
-            try {
-                procId = findProcessIdWithPS(TOR_BIN_PATH);
-            } catch (Exception e2) {
-                Log.e(TAG, "Unable to get proc id for command: " + URLEncoder.encode(TOR_BIN_PATH), e2);
-            }
-        }
-        return procId;
-    }
-
-    private static int findProcessIdWithPidOf(String command) throws Exception {
-        int procId = -1;
-        Runtime r = Runtime.getRuntime();
-        String baseName = new File(command).getName();
-
-        Process procPs = r.exec(new String[]{
-                SHELL_CMD_PIDOF, baseName
-        });
-
-        BufferedReader reader = new BufferedReader(new InputStreamReader(procPs.getInputStream()));
-        String line;
-        while ((line = reader.readLine()) != null) {
-            try {
-                procId = Integer.parseInt(line.trim());
-                break;
-            } catch (NumberFormatException e) {
-                Log.e("TorServiceUtils", "unable to parse process pid: " + line, e);
-            }
-        }
-        return procId;
-    }
-
-    private static int findProcessIdWithPS(String command) throws Exception {
-        int procId = -1;
-        Runtime r = Runtime.getRuntime();
-
-        Process procPs = r.exec(SHELL_CMD_PS);
-
-        BufferedReader reader = new BufferedReader(new InputStreamReader(procPs.getInputStream()));
-        String line;
-        while ((line = reader.readLine()) != null) {
-            if (line.contains(' ' + command)) {
-                StringTokenizer st = new StringTokenizer(line, " ");
-                st.nextToken();
-                procId = Integer.parseInt(st.nextToken().trim());
-                break;
-            }
-        }
-        return procId;
-    }
 
     public static boolean isOrbotInstalled(Context context) {
         PackageManager pm = context.getPackageManager();

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -736,7 +736,7 @@
 	<string name="disable_now">Disable now</string>
 	<string name="start_orbot">Start Orbot</string>
 	<string name="start_orbot_dialog_title">Start Orbot?</string>
-	<string name="start_orbot_dialog_description">Looks like Orbot is not started on your device. Would you like to start it or uncheck Tor?</string>
+	<string name="start_orbot_dialog_description">Looks like Orbot is not started on your device. Would you like to start it?</string>
 	<string name="download_orbot">Download Orbot</string>
 	<string name="install_orbot_dialog_title">Install Orbot?</string>
 	<string name="install_orbot_dialog_description">You must have Orbot installed and activated to proxy traffic through it. Would you like to install it?</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -734,4 +734,10 @@
 	<string name="error_trustkey_hint_mutual">Hint: In some cases this can be fixed by adding each other your contact lists.</string>
 	<string name="disable_encryption_message">Are you sure you want to disable OMEMO encryption for this conversation?\nThis will allow your server administrator to read your messages, but it might be the only way to communicate with people using outdated clients.</string>
 	<string name="disable_now">Disable now</string>
+	<string name="start_orbot">Start Orbot</string>
+	<string name="start_orbot_dialog_title">Start Orbot?</string>
+	<string name="start_orbot_dialog_description">Looks like Orbot is not started on your device. Would you like to start it or uncheck Tor?</string>
+	<string name="download_orbot">Download Orbot</string>
+	<string name="install_orbot_dialog_title">Install Orbot?</string>
+	<string name="install_orbot_dialog_description">You must have Orbot installed and activated to proxy traffic through it. Would you like to install it?</string>
 </resources>


### PR DESCRIPTION
This pr tries to solve #1980. It checks the tor status availability by already present  `account status` callbacks in `ConversationActivity` . It shows a dialog if orbot is not started, and places a gap of a hour between two dialogs to prevent spam. 