### PR TITLE
Show full chat topic in conference info.

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -54,6 +54,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 			inviteToConversation(mConversation);
 		}
 	};
+	private TextView mTopic;
 	private TextView mYourNick;
 	private ImageView mYourPhoto;
 	private TextView mFullJid;
@@ -231,6 +232,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_muc_details);
+		mTopic = findViewById(R.id.muc_topic);
 		mYourNick = (TextView) findViewById(R.id.muc_your_nick);
 		mYourPhoto = (ImageView) findViewById(R.id.your_photo);
 		ImageButton mEditNickButton = (ImageButton) findViewById(R.id.edit_nick_button);
@@ -550,6 +552,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 		mAccountJid.setText(getString(R.string.using_account, account));
 		mYourPhoto.setImageBitmap(avatarService().get(mConversation.getAccount(), getPixel(48)));
 		setTitle(mConversation.getName());
+		mTopic.setText(mucOptions.getSubject());
 		mFullJid.setText(mConversation.getJid().toBareJid().toString());
 		mYourNick.setText(mucOptions.getActualNick());
 		TextView mRoleAffiliaton = (TextView) findViewById(R.id.muc_role);

--- a/src/main/res/layout/activity_muc_details.xml
+++ b/src/main/res/layout/activity_muc_details.xml
@@ -11,6 +11,26 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/activity_vertical_margin"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginRight="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:orientation="vertical"
+        android:background="?attr/infocard_border"
+        android:padding="@dimen/infocard_padding">
+        <TextView
+            android:id="@+id/muc_topic"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:autoLink="all"
+            android:text="@string/edit_subject_hint"
+            android:textColor="?attr/color_text_primary"
+            android:textSize="?attr/TextSizeHeadline"/>
+    </LinearLayout>
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Conversations lacks a practical way of viewing chat topics that are longer than a few words  due to truncation. This adds a box to the top of the conference details screen containing the full topic as well as making links clickable.

![layout-2018-03-04-125712](https://user-images.githubusercontent.com/120919/36948653-2090b944-1fac-11e8-9298-f4c48c3840f1.png)

#1783 