### PR TITLE
remove deprecated method

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
@@ -623,7 +623,7 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 		mSearchEditText.addTextChangedListener(mSearchTextWatcher);
 		mSearchEditText.setOnEditorActionListener(mSearchDone);
 		if (mInitialJid != null) {
-			MenuItemCompat.expandActionView(mMenuSearchView);
+			mMenuSearchView.expandActionView();
 			mSearchEditText.append(mInitialJid);
 			filter(mInitialJid);
 		}


### PR DESCRIPTION
This is a very simple pull request which removes the deprecated method `MenuItemCompat.expandActionView(mMenuSearchView);`