### PR TITLE
accountRegisterNew stays invisible if DISALLOW_REGISTRATION_IN_UI = true

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -967,7 +967,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 			}
 			this.binding.accountRegisterNew.setVisibility(View.GONE);
 		} else {
-			this.binding.accountRegisterNew.setVisibility(mInitMode ? View.VISIBLE : View.GONE);
+			this.binding.accountRegisterNew.setVisibility(mInitMode && !Config.DISALLOW_REGISTRATION_IN_UI ? View.VISIBLE : View.GONE);
 		}
 		if (this.mAccount.isOnlineAndConnected() && !this.mFetchingAvatar) {
 			Features features = this.mAccount.getXmppConnection().getFeatures();


### PR DESCRIPTION
If you set DISALLOW_REGISTRATION_IN_UI to true in Config.java, the accountRegistrationNew checkbox will be visible right after you have pressed the save button. This seems to be a bug.