### PR TITLE
Convert add account menu item to FAB

### DIFF
--- a/src/main/res/layout/activity_manage_accounts.xml
+++ b/src/main/res/layout/activity_manage_accounts.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:background="?attr/color_background_primary" >
-
+    android:background="?attr/color_background_primary">
     <ListView
         android:id="@+id/account_list"
         android:layout_width="fill_parent"
@@ -12,5 +10,21 @@
         android:divider="@android:color/transparent"
         android:dividerHeight="0dp" >
     </ListView>
-
-</LinearLayout>
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/action_add_account"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:src="?attr/icon_add_person"
+        android:layout_margin="16dp"
+        android:title="@string/action_add_account"/>
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/action_add_account_with_cert"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:src="?attr/icon_add_person"
+        android:layout_margin="16dp"
+        android:visibility="gone"
+        android:title="@string/action_add_account_with_certificate"/>
+</FrameLayout>

--- a/src/main/res/menu/manageaccounts.xml
+++ b/src/main/res/menu/manageaccounts.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
 	  xmlns:app="http://schemas.android.com/apk/res-auto">
-
-	<item
-		android:id="@+id/action_add_account"
-		android:icon="?attr/icon_add_person"
-		app:showAsAction="always"
-		android:title="@string/action_add_account"/>
-	<item
-		android:id="@+id/action_add_account_with_cert"
-		app:showAsAction="never"
-		android:icon="?attr/icon_add_person"
-		android:title="@string/action_add_account_with_certificate"
-		android:visible="true"/>
 	<item
 		android:id="@+id/action_enable_all"
 		android:title="@string/enable_all_accounts"/>
@@ -24,5 +12,4 @@
 		android:orderInCategory="100"
 		app:showAsAction="never"
 		android:title="@string/action_settings"/>
-
 </menu>


### PR DESCRIPTION
Opening the conversations list and creating new conversations have been converted to floating action buttons. This PR does the same for the new account and new account from certificate menu items on the manage accounts screen:

![screenshot_20180312-002346](https://user-images.githubusercontent.com/512573/37267061-0d853a06-258c-11e8-87a3-0dbc3f9d65bf.png)