### PR TITLE
Retain dialog across configuration change

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/CreateConferenceDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/CreateConferenceDialog.java
@@ -1,0 +1,82 @@
+package eu.siacs.conversations.ui;
+
+import android.app.Dialog;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.Spinner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.siacs.conversations.R;
+
+public class CreateConferenceDialog extends DialogFragment {
+
+    private static final String ACCOUNTS_LIST_KEY = "activated_accounts_list";
+    private CreateConferenceDialogListener mListener;
+
+    public static CreateConferenceDialog newInstance(List<String> accounts) {
+        CreateConferenceDialog dialog = new CreateConferenceDialog();
+        Bundle bundle =  new Bundle();
+        bundle.putStringArrayList(ACCOUNTS_LIST_KEY, (ArrayList<String>) accounts);
+        dialog.setArguments(bundle);
+        return dialog;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.dialog_title_create_conference);
+        final View dialogView = getActivity().getLayoutInflater().inflate(R.layout.create_conference_dialog, null);
+        final Spinner spinner = dialogView.findViewById(R.id.account);
+        final EditText subject = dialogView.findViewById(R.id.subject);
+        ArrayList<String> mActivatedAccounts = getArguments().getStringArrayList(ACCOUNTS_LIST_KEY);
+        StartConversationActivity.populateAccountSpinner(getActivity(), mActivatedAccounts, spinner);
+        builder.setView(dialogView);
+        builder.setPositiveButton(R.string.choose_participants, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                mListener.onCreateDialogPositiveClick(spinner, subject.getText().toString());
+            }
+        });
+        builder.setNegativeButton(R.string.cancel, null);
+        return builder.create();
+    }
+
+    public interface CreateConferenceDialogListener {
+        void onCreateDialogPositiveClick(Spinner spinner, String subject);
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        try {
+            mListener = (CreateConferenceDialogListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString()
+                    + " must implement CreateConferenceDialogListener");
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        Dialog dialog = getDialog();
+        if (dialog != null && getRetainInstance()) {
+            dialog.setDismissMessage(null);
+        }
+        super.onDestroyView();
+    }
+}

--- a/src/main/java/eu/siacs/conversations/ui/JoinConferenceDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/JoinConferenceDialog.java
@@ -1,0 +1,102 @@
+package eu.siacs.conversations.ui;
+
+import android.app.Dialog;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
+import android.view.View;
+import android.widget.AutoCompleteTextView;
+import android.widget.CheckBox;
+import android.widget.Checkable;
+import android.widget.Spinner;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import eu.siacs.conversations.R;
+import eu.siacs.conversations.ui.adapter.KnownHostsAdapter;
+import eu.siacs.conversations.ui.util.DelayedHintHelper;
+
+public class JoinConferenceDialog extends DialogFragment {
+
+    private static final String PREFILLED_JID_KEY = "prefilled_jid";
+    private static final String ACCOUNTS_LIST_KEY = "activated_accounts_list";
+    private static final String CONFERENCE_HOSTS_KEY = "known_conference_hosts";
+    private JoinConferenceDialogListener mListener;
+
+    public static JoinConferenceDialog newInstance(String prefilledJid, List<String> accounts, Collection<String> conferenceHosts) {
+        JoinConferenceDialog dialog = new JoinConferenceDialog();
+        Bundle bundle =  new Bundle();
+        bundle.putString(PREFILLED_JID_KEY, prefilledJid);
+        bundle.putStringArrayList(ACCOUNTS_LIST_KEY, (ArrayList<String>) accounts);
+        bundle.putSerializable(CONFERENCE_HOSTS_KEY, (HashSet) conferenceHosts);
+        dialog.setArguments(bundle);
+        return dialog;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.dialog_title_join_conference);
+        final View dialogView = getActivity().getLayoutInflater().inflate(R.layout.join_conference_dialog, null);
+        final Spinner spinner = dialogView.findViewById(R.id.account);
+        final AutoCompleteTextView jid = dialogView.findViewById(R.id.jid);
+        DelayedHintHelper.setHint(R.string.conference_address_example, jid);
+        jid.setAdapter(new KnownHostsAdapter(getActivity(), R.layout.simple_list_item, (Collection<String>) getArguments().getSerializable(CONFERENCE_HOSTS_KEY)));
+        String prefilledJid = getArguments().getString(PREFILLED_JID_KEY);
+        if (prefilledJid != null) {
+            jid.append(prefilledJid);
+        }
+        final Checkable bookmarkCheckBox = (CheckBox) dialogView
+                .findViewById(R.id.bookmark);
+        StartConversationActivity.populateAccountSpinner(getActivity(), getArguments().getStringArrayList(ACCOUNTS_LIST_KEY), spinner);
+        builder.setView(dialogView);
+        builder.setPositiveButton(R.string.join, null);
+        builder.setNegativeButton(R.string.cancel, null);
+        AlertDialog dialog = builder.create();
+        dialog.show();
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mListener.onJoinDialogPositiveClick(dialog, spinner, jid, bookmarkCheckBox.isChecked());
+            }
+        });
+        return dialog;
+    }
+
+    public interface JoinConferenceDialogListener {
+        void onJoinDialogPositiveClick(Dialog dialog, Spinner spinner, AutoCompleteTextView jid, boolean isBookmarkChecked);
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        try {
+            mListener = (JoinConferenceDialogListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString()
+                    + " must implement JoinConferenceDialogListener");
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        Dialog dialog = getDialog();
+        if (dialog != null && getRetainInstance()) {
+            dialog.setDismissMessage(null);
+        }
+        super.onDestroyView();
+    }
+}

--- a/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
@@ -83,7 +83,7 @@ import eu.siacs.conversations.xmpp.OnUpdateBlocklist;
 import eu.siacs.conversations.xmpp.XmppConnection;
 import rocks.xmpp.addr.Jid;
 
-public class StartConversationActivity extends XmppActivity implements OnRosterUpdate, OnUpdateBlocklist {
+public class StartConversationActivity extends XmppActivity implements OnRosterUpdate, OnUpdateBlocklist, CreateConferenceDialog.CreateConferenceDialogListener, JoinConferenceDialog.JoinConferenceDialogListener {
 
 	private final int REQUEST_SYNC_CONTACTS = 0x28cf;
 	private final int REQUEST_CREATE_CONFERENCE = 0x39da;
@@ -100,7 +100,6 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 	private Invite mPendingInvite = null;
 	private EditText mSearchEditText;
 	private AtomicBoolean mRequestedContactsPermission = new AtomicBoolean(false);
-	private Dialog mCurrentDialog = null;
 	private boolean mHideOfflineContacts = false;
 	private MenuItem.OnActionExpandListener mOnActionExpandListener = new MenuItem.OnActionExpandListener() {
 
@@ -321,14 +320,6 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 	}
 
 	@Override
-	public void onStop() {
-		if (mCurrentDialog != null) {
-			mCurrentDialog.dismiss();
-		}
-		super.onStop();
-	}
-
-	@Override
 	public void onNewIntent(Intent intent) {
 		if (xmppConnectionServiceBound) {
 			handleIntent(intent);
@@ -483,106 +474,18 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 				return true;
 			}
 		});
-
-		mCurrentDialog = dialog.show();
+		dialog.show();
 	}
 
 	@SuppressLint("InflateParams")
 	protected void showJoinConferenceDialog(final String prefilledJid) {
-		final AlertDialog.Builder builder = new AlertDialog.Builder(this);
-		builder.setTitle(R.string.dialog_title_join_conference);
-		final View dialogView = getLayoutInflater().inflate(R.layout.join_conference_dialog, null);
-		final Spinner spinner = dialogView.findViewById(R.id.account);
-		final AutoCompleteTextView jid = dialogView.findViewById(R.id.jid);
-		DelayedHintHelper.setHint(R.string.conference_address_example,jid);
-		jid.setAdapter(new KnownHostsAdapter(this, R.layout.simple_list_item, mKnownConferenceHosts));
-		if (prefilledJid != null) {
-			jid.append(prefilledJid);
-		}
-		populateAccountSpinner(this, mActivatedAccounts, spinner);
-		final Checkable bookmarkCheckBox = (CheckBox) dialogView
-				.findViewById(R.id.bookmark);
-		builder.setView(dialogView);
-		builder.setNegativeButton(R.string.cancel, null);
-		builder.setPositiveButton(R.string.join, null);
-		final AlertDialog dialog = builder.create();
-		dialog.show();
-		mCurrentDialog = dialog;
-		dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
-			if (!xmppConnectionServiceBound) {
-				return;
-			}
-			final Account account = getSelectedAccount(spinner);
-			if (account == null) {
-				return;
-			}
-			final Jid conferenceJid;
-			try {
-				conferenceJid = Jid.of(jid.getText().toString());
-			} catch (final IllegalArgumentException e) {
-				jid.setError(getString(R.string.invalid_jid));
-				return;
-			}
-
-			if (bookmarkCheckBox.isChecked()) {
-				if (account.hasBookmarkFor(conferenceJid)) {
-					jid.setError(getString(R.string.bookmark_already_exists));
-				} else {
-					final Bookmark bookmark = new Bookmark(account, conferenceJid.asBareJid());
-					bookmark.setAutojoin(getPreferences().getBoolean("autojoin", getResources().getBoolean(R.bool.autojoin)));
-					String nick = conferenceJid.getResource();
-					if (nick != null && !nick.isEmpty()) {
-						bookmark.setNick(nick);
-					}
-					account.getBookmarks().add(bookmark);
-					xmppConnectionService.pushBookmarks(account);
-					final Conversation conversation = xmppConnectionService
-							.findOrCreateConversation(account, conferenceJid, true, true, true);
-					bookmark.setConversation(conversation);
-					dialog.dismiss();
-					mCurrentDialog = null;
-					switchToConversation(conversation);
-				}
-			} else {
-				final Conversation conversation = xmppConnectionService
-						.findOrCreateConversation(account, conferenceJid, true, true, true);
-				dialog.dismiss();
-				mCurrentDialog = null;
-				switchToConversation(conversation);
-			}
-		});
+		JoinConferenceDialog dialog = JoinConferenceDialog.newInstance(prefilledJid, mActivatedAccounts, mKnownConferenceHosts);
+		dialog.show(getSupportFragmentManager(),"join_conference_dialog");
 	}
 
 	private void showCreateConferenceDialog() {
-		final AlertDialog.Builder builder = new AlertDialog.Builder(this);
-		builder.setTitle(R.string.dialog_title_create_conference);
-		final View dialogView = getLayoutInflater().inflate(R.layout.create_conference_dialog, null);
-		final Spinner spinner = dialogView.findViewById(R.id.account);
-		final EditText subject = dialogView.findViewById(R.id.subject);
-		populateAccountSpinner(this, mActivatedAccounts, spinner);
-		builder.setView(dialogView);
-		builder.setPositiveButton(R.string.choose_participants, new OnClickListener() {
-			@Override
-			public void onClick(DialogInterface dialog, int which) {
-				if (!xmppConnectionServiceBound) {
-					return;
-				}
-				final Account account = getSelectedAccount(spinner);
-				if (account == null) {
-					return;
-				}
-				Intent intent = new Intent(getApplicationContext(), ChooseContactActivity.class);
-				intent.putExtra("multiple", true);
-				intent.putExtra("show_enter_jid", true);
-				intent.putExtra("subject", subject.getText().toString());
-				intent.putExtra(EXTRA_ACCOUNT, account.getJid().asBareJid().toString());
-				intent.putExtra(ChooseContactActivity.EXTRA_TITLE_RES_ID, R.string.choose_participants);
-				startActivityForResult(intent, REQUEST_CREATE_CONFERENCE);
-			}
-		});
-		builder.setNegativeButton(R.string.cancel, null);
-		mCurrentDialog = builder.create();
-		mCurrentDialog.show();
+		CreateConferenceDialog dialog = CreateConferenceDialog.newInstance(mActivatedAccounts);
+		dialog.show(getSupportFragmentManager(),"create_conference_dialog");
 	}
 
 	private Account getSelectedAccount(Spinner spinner) {
@@ -962,6 +865,67 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 	protected void refreshUiReal() {
 		if (mSearchEditText != null) {
 			filter(mSearchEditText.getText().toString());
+		}
+	}
+
+	@Override
+	public void onCreateDialogPositiveClick(Spinner spinner,String subject) {
+		if (!xmppConnectionServiceBound) {
+			return;
+		}
+		final Account account = getSelectedAccount(spinner);
+		if (account == null) {
+			return;
+		}
+		Intent intent = new Intent(getApplicationContext(), ChooseContactActivity.class);
+		intent.putExtra("multiple", true);
+		intent.putExtra("show_enter_jid", true);
+		intent.putExtra("subject", subject);
+		intent.putExtra(EXTRA_ACCOUNT, account.getJid().asBareJid().toString());
+		intent.putExtra(ChooseContactActivity.EXTRA_TITLE_RES_ID, R.string.choose_participants);
+		startActivityForResult(intent, REQUEST_CREATE_CONFERENCE);
+	}
+
+	@Override
+	public void onJoinDialogPositiveClick(Dialog dialog, Spinner spinner, AutoCompleteTextView jid, boolean isBookmarkChecked) {
+		if (!xmppConnectionServiceBound) {
+			return;
+		}
+		final Account account = getSelectedAccount(spinner);
+		if (account == null) {
+			return;
+		}
+		final Jid conferenceJid;
+		try {
+			conferenceJid = Jid.of(jid.getText().toString());
+		} catch (final IllegalArgumentException e) {
+			jid.setError(getString(R.string.invalid_jid));
+			return;
+		}
+
+		if (isBookmarkChecked) {
+			if (account.hasBookmarkFor(conferenceJid)) {
+				jid.setError(getString(R.string.bookmark_already_exists));
+			} else {
+				final Bookmark bookmark = new Bookmark(account, conferenceJid.asBareJid());
+				bookmark.setAutojoin(getPreferences().getBoolean("autojoin", getResources().getBoolean(R.bool.autojoin)));
+				String nick = conferenceJid.getResource();
+				if (nick != null && !nick.isEmpty()) {
+					bookmark.setNick(nick);
+				}
+				account.getBookmarks().add(bookmark);
+				xmppConnectionService.pushBookmarks(account);
+				final Conversation conversation = xmppConnectionService
+						.findOrCreateConversation(account, conferenceJid, true, true, true);
+				bookmark.setConversation(conversation);
+				dialog.dismiss();
+				switchToConversation(conversation);
+			}
+		} else {
+			final Conversation conversation = xmppConnectionService
+					.findOrCreateConversation(account, conferenceJid, true, true, true);
+			dialog.dismiss();
+			switchToConversation(conversation);
 		}
 	}
 


### PR DESCRIPTION
This pull request attempts to solve #2860. The create conference and join conference dialogs are now retained across configuration change, by the use of dialog fragments.  