### PR TITLE
Retain dialog across configuration change

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/BlocklistActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/BlocklistActivity.java
@@ -1,6 +1,8 @@
 package eu.siacs.conversations.ui;
 
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
 import android.text.Editable;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -62,6 +64,12 @@ public class BlocklistActivity extends AbstractSearchableListItemActivity implem
 	}
 
 	protected void showEnterJidDialog() {
+		FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+		Fragment prev = getSupportFragmentManager().findFragmentByTag("dialog");
+		if (prev != null) {
+			ft.remove(prev);
+		}
+		ft.addToBackStack(null);
 		EnterJidDialog dialog = EnterJidDialog.newInstance(
 				mKnownHosts, null,
 				getString(R.string.block_jabber_id), getString(R.string.block),
@@ -76,7 +84,7 @@ public class BlocklistActivity extends AbstractSearchableListItemActivity implem
 			return true;
 		});
 
-		dialog.show(getSupportFragmentManager(), "block_contact_dialog");
+		dialog.show(ft, "dialog");
 	}
 
 	protected void refreshUiReal() {

--- a/src/main/java/eu/siacs/conversations/ui/BlocklistActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/BlocklistActivity.java
@@ -62,8 +62,8 @@ public class BlocklistActivity extends AbstractSearchableListItemActivity implem
 	}
 
 	protected void showEnterJidDialog() {
-		EnterJidDialog dialog = new EnterJidDialog(
-				this, mKnownHosts, null,
+		EnterJidDialog dialog = EnterJidDialog.newInstance(
+				mKnownHosts, null,
 				getString(R.string.block_jabber_id), getString(R.string.block),
 				null, account.getJid().asBareJid().toString(), true
 		);
@@ -76,7 +76,7 @@ public class BlocklistActivity extends AbstractSearchableListItemActivity implem
 			return true;
 		});
 
-		dialog.show();
+		dialog.show(getSupportFragmentManager(), "block_contact_dialog");
 	}
 
 	protected void refreshUiReal() {

--- a/src/main/java/eu/siacs/conversations/ui/ChooseContactActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ChooseContactActivity.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
 import android.view.ActionMode;
 import android.view.Menu;
@@ -230,6 +232,12 @@ public class ChooseContactActivity extends AbstractSearchableListItemActivity {
 	}
 
 	protected void showEnterJidDialog(XmppUri uri) {
+		FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+		Fragment prev = getSupportFragmentManager().findFragmentByTag("dialog");
+		if (prev != null) {
+			ft.remove(prev);
+		}
+		ft.addToBackStack(null);
 		Jid jid = uri == null ? null : uri.getJid();
 		EnterJidDialog dialog = EnterJidDialog.newInstance(
 				mKnownHosts,
@@ -256,7 +264,7 @@ public class ChooseContactActivity extends AbstractSearchableListItemActivity {
 			return true;
 		});
 
-		dialog.show(getSupportFragmentManager(), "enter_contact_dialog");
+		dialog.show(ft, "dialog");
 	}
 
 	@Override

--- a/src/main/java/eu/siacs/conversations/ui/ChooseContactActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ChooseContactActivity.java
@@ -231,8 +231,7 @@ public class ChooseContactActivity extends AbstractSearchableListItemActivity {
 
 	protected void showEnterJidDialog(XmppUri uri) {
 		Jid jid = uri == null ? null : uri.getJid();
-		EnterJidDialog dialog = new EnterJidDialog(
-				this,
+		EnterJidDialog dialog = EnterJidDialog.newInstance(
 				mKnownHosts,
 				mActivatedAccounts,
 				getString(R.string.enter_contact),
@@ -257,7 +256,7 @@ public class ChooseContactActivity extends AbstractSearchableListItemActivity {
 			return true;
 		});
 
-		dialog.show();
+		dialog.show(getSupportFragmentManager(), "enter_contact_dialog");
 	}
 
 	@Override

--- a/src/main/java/eu/siacs/conversations/ui/CreateConferenceDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/CreateConferenceDialog.java
@@ -1,0 +1,82 @@
+package eu.siacs.conversations.ui;
+
+import android.app.Dialog;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.Spinner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.siacs.conversations.R;
+
+public class CreateConferenceDialog extends DialogFragment {
+
+    private static final String ACCOUNTS_LIST_KEY = "activated_accounts_list";
+    private CreateConferenceDialogListener mListener;
+
+    public static CreateConferenceDialog newInstance(List<String> accounts) {
+        CreateConferenceDialog dialog = new CreateConferenceDialog();
+        Bundle bundle =  new Bundle();
+        bundle.putStringArrayList(ACCOUNTS_LIST_KEY, (ArrayList<String>) accounts);
+        dialog.setArguments(bundle);
+        return dialog;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.dialog_title_create_conference);
+        final View dialogView = getActivity().getLayoutInflater().inflate(R.layout.create_conference_dialog, null);
+        final Spinner spinner = dialogView.findViewById(R.id.account);
+        final EditText subject = dialogView.findViewById(R.id.subject);
+        ArrayList<String> mActivatedAccounts = getArguments().getStringArrayList(ACCOUNTS_LIST_KEY);
+        StartConversationActivity.populateAccountSpinner(getActivity(), mActivatedAccounts, spinner);
+        builder.setView(dialogView);
+        builder.setPositiveButton(R.string.choose_participants, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                mListener.onCreateDialogPositiveClick(spinner, subject.getText().toString());
+            }
+        });
+        builder.setNegativeButton(R.string.cancel, null);
+        return builder.create();
+    }
+
+    public interface CreateConferenceDialogListener {
+        void onCreateDialogPositiveClick(Spinner spinner, String subject);
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        try {
+            mListener = (CreateConferenceDialogListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString()
+                    + " must implement CreateConferenceDialogListener");
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        Dialog dialog = getDialog();
+        if (dialog != null && getRetainInstance()) {
+            dialog.setDismissMessage(null);
+        }
+        super.onDestroyView();
+    }
+}

--- a/src/main/java/eu/siacs/conversations/ui/CreateConferenceDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/CreateConferenceDialog.java
@@ -1,6 +1,7 @@
 package eu.siacs.conversations.ui;
 
 import android.app.Dialog;
+import android.databinding.DataBindingUtil;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.content.Context;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import eu.siacs.conversations.R;
+import eu.siacs.conversations.databinding.CreateConferenceDialogBinding;
 
 public class CreateConferenceDialog extends DialogFragment {
 
@@ -40,16 +42,14 @@ public class CreateConferenceDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(R.string.dialog_title_create_conference);
-        final View dialogView = getActivity().getLayoutInflater().inflate(R.layout.create_conference_dialog, null);
-        final Spinner spinner = dialogView.findViewById(R.id.account);
-        final EditText subject = dialogView.findViewById(R.id.subject);
+        CreateConferenceDialogBinding binding = DataBindingUtil.inflate(getActivity().getLayoutInflater(), R.layout.create_conference_dialog, null, false);
         ArrayList<String> mActivatedAccounts = getArguments().getStringArrayList(ACCOUNTS_LIST_KEY);
-        StartConversationActivity.populateAccountSpinner(getActivity(), mActivatedAccounts, spinner);
-        builder.setView(dialogView);
+        StartConversationActivity.populateAccountSpinner(getActivity(), mActivatedAccounts, binding.account);
+        builder.setView(binding.getRoot());
         builder.setPositiveButton(R.string.choose_participants, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                mListener.onCreateDialogPositiveClick(spinner, subject.getText().toString());
+                mListener.onCreateDialogPositiveClick(binding.account, binding.subject.getText().toString());
             }
         });
         builder.setNegativeButton(R.string.cancel, null);

--- a/src/main/java/eu/siacs/conversations/ui/EnterJidDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/EnterJidDialog.java
@@ -1,16 +1,18 @@
 package eu.siacs.conversations.ui;
 
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
-import android.content.Context;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.Spinner;
-import android.widget.TextView;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import eu.siacs.conversations.Config;
@@ -19,41 +21,54 @@ import eu.siacs.conversations.ui.adapter.KnownHostsAdapter;
 import eu.siacs.conversations.ui.util.DelayedHintHelper;
 import rocks.xmpp.addr.Jid;
 
-public class EnterJidDialog {
-	public interface OnEnterJidDialogPositiveListener {
-		boolean onEnterJidDialogPositive(Jid account, Jid contact) throws EnterJidDialog.JidError;
-	}
+public class EnterJidDialog extends DialogFragment{
 
-	public static class JidError extends Exception {
-		final String msg;
+	private OnEnterJidDialogPositiveListener mListener = null;
 
-		public JidError(final String msg) {
-			this.msg = msg;
-		}
+	private static final String TITLE_KEY = "title";
+	private static final String POSITIVE_BUTTON_KEY = "positive_button";
+	private static final String PREFILLED_JID_KEY = "prefilled_jid";
+	private static final String ACCOUNT_KEY = "account";
+	private static final String ALLOW_EDIT_JID_KEY = "allow_edit_jid";
+	private static final String ACCOUNTS_LIST_KEY = "activated_accounts_list";
+	private static final String CONFERENCE_HOSTS_KEY = "known_conference_hosts";
 
-		public String toString() {
-			return msg;
-		}
-	}
-
-	protected final AlertDialog dialog;
-	protected View.OnClickListener dialogOnClick;
-	protected OnEnterJidDialogPositiveListener listener = null;
-
-	public EnterJidDialog(
-			final Context context, Collection<String> knownHosts, final List<String> activatedAccounts,
+	public static EnterJidDialog newInstance(
+			Collection<String> knownHosts, final List<String> activatedAccounts,
 			final String title, final String positiveButton,
-			final String prefilledJid, final String account, boolean allowEditJid
-	) {
-		AlertDialog.Builder builder = new AlertDialog.Builder(context);
-		builder.setTitle(title);
-		View dialogView = LayoutInflater.from(context).inflate(R.layout.enter_jid_dialog, null);
+			final String prefilledJid, final String account, boolean allowEditJid) {
+		EnterJidDialog dialog = new EnterJidDialog();
+		Bundle bundle  = new Bundle();
+		bundle.putString(TITLE_KEY, title);
+		bundle.putString(POSITIVE_BUTTON_KEY, positiveButton);
+		bundle.putString(PREFILLED_JID_KEY, prefilledJid);
+		bundle.putString(ACCOUNT_KEY, account);
+		bundle.putBoolean(ALLOW_EDIT_JID_KEY, allowEditJid);
+		bundle.putStringArrayList(ACCOUNTS_LIST_KEY, (ArrayList<String>) activatedAccounts);
+		bundle.putSerializable(CONFERENCE_HOSTS_KEY, (HashSet) knownHosts);
+		dialog.setArguments(bundle);
+		return dialog;
+	}
+
+	@Override
+	public void onActivityCreated(Bundle savedInstanceState) {
+		super.onActivityCreated(savedInstanceState);
+		setRetainInstance(true);
+	}
+
+	@NonNull
+	@Override
+	public Dialog onCreateDialog(Bundle savedInstanceState) {
+		final AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+		builder.setTitle(getArguments().getString(TITLE_KEY));
+		View dialogView = getActivity().getLayoutInflater().inflate(R.layout.enter_jid_dialog, null);
 		final Spinner spinner = dialogView.findViewById(R.id.account);
 		final AutoCompleteTextView jid = dialogView.findViewById(R.id.jid);
-		jid.setAdapter(new KnownHostsAdapter(context, R.layout.simple_list_item, knownHosts));
+		jid.setAdapter(new KnownHostsAdapter(getActivity(), R.layout.simple_list_item, (Collection<String>) getArguments().getSerializable(CONFERENCE_HOSTS_KEY)));
+		String prefilledJid = getArguments().getString(PREFILLED_JID_KEY);
 		if (prefilledJid != null) {
 			jid.append(prefilledJid);
-			if (!allowEditJid) {
+			if (!getArguments().getBoolean(ALLOW_EDIT_JID_KEY)) {
 				jid.setFocusable(false);
 				jid.setFocusableInTouchMode(false);
 				jid.setClickable(false);
@@ -63,10 +78,11 @@ public class EnterJidDialog {
 
 		DelayedHintHelper.setHint(R.string.account_settings_example_jabber_id,jid);
 
+		String account = getArguments().getString(ACCOUNT_KEY);
 		if (account == null) {
-			StartConversationActivity.populateAccountSpinner(context, activatedAccounts, spinner);
+			StartConversationActivity.populateAccountSpinner(getActivity(), getArguments().getStringArrayList(ACCOUNTS_LIST_KEY), spinner);
 		} else {
-			ArrayAdapter<String> adapter = new ArrayAdapter<>(context,
+			ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(),
 					R.layout.simple_list_item,
 					new String[] { account });
 			spinner.setEnabled(false);
@@ -76,10 +92,10 @@ public class EnterJidDialog {
 
 		builder.setView(dialogView);
 		builder.setNegativeButton(R.string.cancel, null);
-		builder.setPositiveButton(positiveButton, null);
-		this.dialog = builder.create();
+		builder.setPositiveButton(getArguments().getString(POSITIVE_BUTTON_KEY), null);
+		AlertDialog dialog = builder.create();
 
-		this.dialogOnClick = v -> {
+		View.OnClickListener dialogOnClick = v -> {
 			final Jid accountJid;
 			if (!spinner.isEnabled() && account == null) {
 				return;
@@ -97,13 +113,13 @@ public class EnterJidDialog {
 			try {
 				contactJid = Jid.of(jid.getText().toString());
 			} catch (final IllegalArgumentException e) {
-				jid.setError(context.getString(R.string.invalid_jid));
+				jid.setError(getActivity().getString(R.string.invalid_jid));
 				return;
 			}
 
-			if(listener != null) {
+			if(mListener != null) {
 				try {
-					if(listener.onEnterJidDialogPositive(accountJid, contactJid)) {
+					if(mListener.onEnterJidDialogPositive(accountJid, contactJid)) {
 						dialog.dismiss();
 					}
 				} catch(JidError error) {
@@ -111,15 +127,37 @@ public class EnterJidDialog {
 				}
 			}
 		};
+		dialog.show();
+		dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(dialogOnClick);
+		return dialog;
 	}
 
 	public void setOnEnterJidDialogPositiveListener(OnEnterJidDialogPositiveListener listener) {
-		this.listener = listener;
+		this.mListener = listener;
 	}
 
-	public Dialog show() {
-		this.dialog.show();
-		this.dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(this.dialogOnClick);
-		return this.dialog;
+	public interface OnEnterJidDialogPositiveListener {
+		boolean onEnterJidDialogPositive(Jid account, Jid contact) throws EnterJidDialog.JidError;
+	}
+
+	public static class JidError extends Exception {
+		final String msg;
+
+		public JidError(final String msg) {
+			this.msg = msg;
+		}
+
+		public String toString() {
+			return msg;
+		}
+	}
+
+	@Override
+	public void onDestroyView() {
+		Dialog dialog = getDialog();
+		if (dialog != null && getRetainInstance()) {
+			dialog.setDismissMessage(null);
+		}
+		super.onDestroyView();
 	}
 }

--- a/src/main/java/eu/siacs/conversations/ui/JoinConferenceDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/JoinConferenceDialog.java
@@ -1,6 +1,7 @@
 package eu.siacs.conversations.ui;
 
 import android.app.Dialog;
+import android.databinding.DataBindingUtil;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.content.Context;
@@ -19,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import eu.siacs.conversations.R;
+import eu.siacs.conversations.databinding.JoinConferenceDialogBinding;
 import eu.siacs.conversations.ui.adapter.KnownHostsAdapter;
 import eu.siacs.conversations.ui.util.DelayedHintHelper;
 
@@ -50,19 +52,15 @@ public class JoinConferenceDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(R.string.dialog_title_join_conference);
-        final View dialogView = getActivity().getLayoutInflater().inflate(R.layout.join_conference_dialog, null);
-        final Spinner spinner = dialogView.findViewById(R.id.account);
-        final AutoCompleteTextView jid = dialogView.findViewById(R.id.jid);
-        DelayedHintHelper.setHint(R.string.conference_address_example, jid);
-        jid.setAdapter(new KnownHostsAdapter(getActivity(), R.layout.simple_list_item, (Collection<String>) getArguments().getSerializable(CONFERENCE_HOSTS_KEY)));
+        JoinConferenceDialogBinding binding = DataBindingUtil.inflate(getActivity().getLayoutInflater(), R.layout.join_conference_dialog, null, false);
+        DelayedHintHelper.setHint(R.string.conference_address_example, binding.jid);
+        binding.jid.setAdapter(new KnownHostsAdapter(getActivity(), R.layout.simple_list_item, (Collection<String>) getArguments().getSerializable(CONFERENCE_HOSTS_KEY)));
         String prefilledJid = getArguments().getString(PREFILLED_JID_KEY);
         if (prefilledJid != null) {
-            jid.append(prefilledJid);
+            binding.jid.append(prefilledJid);
         }
-        final Checkable bookmarkCheckBox = (CheckBox) dialogView
-                .findViewById(R.id.bookmark);
-        StartConversationActivity.populateAccountSpinner(getActivity(), getArguments().getStringArrayList(ACCOUNTS_LIST_KEY), spinner);
-        builder.setView(dialogView);
+        StartConversationActivity.populateAccountSpinner(getActivity(), getArguments().getStringArrayList(ACCOUNTS_LIST_KEY), binding.account);
+        builder.setView(binding.getRoot());
         builder.setPositiveButton(R.string.join, null);
         builder.setNegativeButton(R.string.cancel, null);
         AlertDialog dialog = builder.create();
@@ -70,7 +68,7 @@ public class JoinConferenceDialog extends DialogFragment {
         dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mListener.onJoinDialogPositiveClick(dialog, spinner, jid, bookmarkCheckBox.isChecked());
+                mListener.onJoinDialogPositiveClick(dialog, binding.account, binding.jid, binding.bookmark.isChecked());
             }
         });
         return dialog;

--- a/src/main/java/eu/siacs/conversations/ui/JoinConferenceDialog.java
+++ b/src/main/java/eu/siacs/conversations/ui/JoinConferenceDialog.java
@@ -1,0 +1,102 @@
+package eu.siacs.conversations.ui;
+
+import android.app.Dialog;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
+import android.view.View;
+import android.widget.AutoCompleteTextView;
+import android.widget.CheckBox;
+import android.widget.Checkable;
+import android.widget.Spinner;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import eu.siacs.conversations.R;
+import eu.siacs.conversations.ui.adapter.KnownHostsAdapter;
+import eu.siacs.conversations.ui.util.DelayedHintHelper;
+
+public class JoinConferenceDialog extends DialogFragment {
+
+    private static final String PREFILLED_JID_KEY = "prefilled_jid";
+    private static final String ACCOUNTS_LIST_KEY = "activated_accounts_list";
+    private static final String CONFERENCE_HOSTS_KEY = "known_conference_hosts";
+    private JoinConferenceDialogListener mListener;
+
+    public static JoinConferenceDialog newInstance(String prefilledJid, List<String> accounts, Collection<String> conferenceHosts) {
+        JoinConferenceDialog dialog = new JoinConferenceDialog();
+        Bundle bundle =  new Bundle();
+        bundle.putString(PREFILLED_JID_KEY, prefilledJid);
+        bundle.putStringArrayList(ACCOUNTS_LIST_KEY, (ArrayList<String>) accounts);
+        bundle.putSerializable(CONFERENCE_HOSTS_KEY, (HashSet) conferenceHosts);
+        dialog.setArguments(bundle);
+        return dialog;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.dialog_title_join_conference);
+        final View dialogView = getActivity().getLayoutInflater().inflate(R.layout.join_conference_dialog, null);
+        final Spinner spinner = dialogView.findViewById(R.id.account);
+        final AutoCompleteTextView jid = dialogView.findViewById(R.id.jid);
+        DelayedHintHelper.setHint(R.string.conference_address_example, jid);
+        jid.setAdapter(new KnownHostsAdapter(getActivity(), R.layout.simple_list_item, (Collection<String>) getArguments().getSerializable(CONFERENCE_HOSTS_KEY)));
+        String prefilledJid = getArguments().getString(PREFILLED_JID_KEY);
+        if (prefilledJid != null) {
+            jid.append(prefilledJid);
+        }
+        final Checkable bookmarkCheckBox = (CheckBox) dialogView
+                .findViewById(R.id.bookmark);
+        StartConversationActivity.populateAccountSpinner(getActivity(), getArguments().getStringArrayList(ACCOUNTS_LIST_KEY), spinner);
+        builder.setView(dialogView);
+        builder.setPositiveButton(R.string.join, null);
+        builder.setNegativeButton(R.string.cancel, null);
+        AlertDialog dialog = builder.create();
+        dialog.show();
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mListener.onJoinDialogPositiveClick(dialog, spinner, jid, bookmarkCheckBox.isChecked());
+            }
+        });
+        return dialog;
+    }
+
+    public interface JoinConferenceDialogListener {
+        void onJoinDialogPositiveClick(Dialog dialog, Spinner spinner, AutoCompleteTextView jid, boolean isBookmarkChecked);
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        try {
+            mListener = (JoinConferenceDialogListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString()
+                    + " must implement JoinConferenceDialogListener");
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        Dialog dialog = getDialog();
+        if (dialog != null && getRetainInstance()) {
+            dialog.setDismissMessage(null);
+        }
+        super.onDestroyView();
+    }
+}

--- a/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
@@ -440,6 +440,12 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 
 	@SuppressLint("InflateParams")
 	protected void showCreateContactDialog(final String prefilledJid, final Invite invite) {
+		FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+		Fragment prev = getSupportFragmentManager().findFragmentByTag("dialog");
+		if (prev != null) {
+			ft.remove(prev);
+		}
+		ft.addToBackStack(null);
 		EnterJidDialog dialog = EnterJidDialog.newInstance(
 				mKnownHosts, mActivatedAccounts,
 				getString(R.string.dialog_title_create_contact), getString(R.string.create),
@@ -474,18 +480,30 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 				return true;
 			}
 		});
-		dialog.show(getSupportFragmentManager(), "create_contact_dialog");
+		dialog.show(ft, "dialog");
 	}
 
 	@SuppressLint("InflateParams")
 	protected void showJoinConferenceDialog(final String prefilledJid) {
-		JoinConferenceDialog dialog = JoinConferenceDialog.newInstance(prefilledJid, mActivatedAccounts, mKnownConferenceHosts);
-		dialog.show(getSupportFragmentManager(),"join_conference_dialog");
+		FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+		Fragment prev = getSupportFragmentManager().findFragmentByTag("dialog");
+		if (prev != null) {
+			ft.remove(prev);
+		}
+		ft.addToBackStack(null);
+		JoinConferenceDialog joinConferenceFragment = JoinConferenceDialog.newInstance(prefilledJid, mActivatedAccounts, mKnownConferenceHosts);
+		joinConferenceFragment.show(ft, "dialog");
 	}
 
 	private void showCreateConferenceDialog() {
-		CreateConferenceDialog dialog = CreateConferenceDialog.newInstance(mActivatedAccounts);
-		dialog.show(getSupportFragmentManager(),"create_conference_dialog");
+		FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+		Fragment prev = getSupportFragmentManager().findFragmentByTag("dialog");
+		if (prev != null) {
+			ft.remove(prev);
+		}
+		ft.addToBackStack(null);
+		CreateConferenceDialog createConferenceFragment = CreateConferenceDialog.newInstance(mActivatedAccounts);
+		createConferenceFragment.show(ft, "dialog");
 	}
 
 	private Account getSelectedAccount(Spinner spinner) {

--- a/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
@@ -440,8 +440,8 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 
 	@SuppressLint("InflateParams")
 	protected void showCreateContactDialog(final String prefilledJid, final Invite invite) {
-		EnterJidDialog dialog = new EnterJidDialog(
-				this, mKnownHosts, mActivatedAccounts,
+		EnterJidDialog dialog = EnterJidDialog.newInstance(
+				mKnownHosts, mActivatedAccounts,
 				getString(R.string.dialog_title_create_contact), getString(R.string.create),
 				prefilledJid, null, invite == null || !invite.hasFingerprints()
 		);
@@ -474,7 +474,7 @@ public class StartConversationActivity extends XmppActivity implements OnRosterU
 				return true;
 			}
 		});
-		dialog.show();
+		dialog.show(getSupportFragmentManager(), "create_contact_dialog");
 	}
 
 	@SuppressLint("InflateParams")

--- a/src/main/res/layout/create_conference_dialog.xml
+++ b/src/main/res/layout/create_conference_dialog.xml
@@ -1,40 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="?attr/dialog_vertical_padding"
-    android:paddingLeft="?attr/dialog_horizontal_padding"
-    android:paddingRight="?attr/dialog_horizontal_padding"
-    android:paddingTop="?attr/dialog_vertical_padding">
-    <TextView
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/your_account"
-        style="@style/InputLabel" />
-    <Spinner
-        android:id="@+id/account"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="?attr/dialog_vertical_padding"
+        android:paddingLeft="?attr/dialog_horizontal_padding"
+        android:paddingRight="?attr/dialog_horizontal_padding"
+        android:paddingTop="?attr/dialog_vertical_padding">
 
-    <View
-        android:focusable="true"
-        android:focusableInTouchMode="true"
-        android:layout_width="0dp"
-        android:layout_height="0dp"/>
-
-    <android.support.design.widget.TextInputLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <android.support.design.widget.TextInputEditText
-            android:id="@+id/subject"
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:nextFocusUp="@+id/subject"
-            android:nextFocusDown="@+id/subject"
-            android:hint="@string/edit_subject_hint"/>
+            android:text="@string/your_account"
+            style="@style/InputLabel" />
 
-    </android.support.design.widget.TextInputLayout>
+        <Spinner
+            android:id="@+id/account"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"/>
 
-</LinearLayout>
+        <View
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:layout_width="0dp"
+            android:layout_height="0dp"/>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/subject"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nextFocusUp="@+id/subject"
+                android:nextFocusDown="@+id/subject"
+                android:hint="@string/edit_subject_hint"/>
+        </android.support.design.widget.TextInputLayout>
+    </LinearLayout>
+</layout>

--- a/src/main/res/layout/enter_jid_dialog.xml
+++ b/src/main/res/layout/enter_jid_dialog.xml
@@ -1,35 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              android:paddingBottom="?attr/dialog_vertical_padding"
-              android:paddingLeft="?attr/dialog_horizontal_padding"
-              android:paddingRight="?attr/dialog_horizontal_padding"
-              android:paddingTop="?attr/dialog_vertical_padding">
-
-    <TextView
-        style="@style/InputLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/your_account"/>
-
-    <Spinner
-        android:id="@+id/account"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"/>
-
-    <android.support.design.widget.TextInputLayout
-        android:id="@+id/account_jid_layout"
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/account_settings_jabber_id">
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="?attr/dialog_vertical_padding"
+        android:paddingLeft="?attr/dialog_horizontal_padding"
+        android:paddingRight="?attr/dialog_horizontal_padding"
+        android:paddingTop="?attr/dialog_vertical_padding">
 
-        <AutoCompleteTextView
-            android:id="@+id/jid"
-            android:layout_width="fill_parent"
+        <TextView
+            style="@style/InputLabel"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:inputType="textEmailAddress"/>
-    </android.support.design.widget.TextInputLayout>
+            android:text="@string/your_account"/>
 
-</LinearLayout>
+        <Spinner
+            android:id="@+id/account"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"/>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/account_jid_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/account_settings_jabber_id">
+
+            <AutoCompleteTextView
+                android:id="@+id/jid"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textEmailAddress"/>
+        </android.support.design.widget.TextInputLayout>
+    </LinearLayout>
+</layout>

--- a/src/main/res/layout/join_conference_dialog.xml
+++ b/src/main/res/layout/join_conference_dialog.xml
@@ -1,43 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              android:paddingBottom="8dp"
-              android:paddingLeft="24dp"
-              android:paddingRight="24dp"
-              android:paddingTop="16dp">
-    <TextView
-        style="@style/InputLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/your_account"/>
-
-    <Spinner
-        android:id="@+id/account"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content" />
-
-    <android.support.design.widget.TextInputLayout
-        android:id="@+id/account_jid_layout"
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/conference_address">
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="8dp"
+        android:paddingLeft="24dp"
+        android:paddingRight="24dp"
+        android:paddingTop="16dp">
 
-        <AutoCompleteTextView
-            android:id="@+id/jid"
-            android:layout_width="fill_parent"
+        <TextView
+            style="@style/InputLabel"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:inputType="textEmailAddress"/>
-    </android.support.design.widget.TextInputLayout>
+            android:text="@string/your_account"/>
 
+        <Spinner
+            android:id="@+id/account"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content" />
 
-    <CheckBox
-        android:id="@+id/bookmark"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:checked="true"
-        android:text="@string/save_as_bookmark"/>
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/account_jid_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/conference_address">
 
-</LinearLayout>
+            <AutoCompleteTextView
+                android:id="@+id/jid"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textEmailAddress"/>
+        </android.support.design.widget.TextInputLayout>
+
+        <CheckBox
+            android:id="@+id/bookmark"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:checked="true"
+            android:text="@string/save_as_bookmark"/>
+    </LinearLayout>
+</layout>


### PR DESCRIPTION
This pull request attempts to solve #2860. The create conference, join conference dialogs and enter jid dialogs are now retained across configuration change, by the use of dialog fragments.