### PR TITLE
Add option to dismiss notification on direct reply

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -395,6 +395,8 @@ public class NotificationService {
 				}
 				RemoteInput remoteInput = new RemoteInput.Builder("text_reply").setLabel(UIHelper.getMessageHint(mXmppConnectionService, conversation)).build();
 				PendingIntent markAsReadPendingIntent = createReadPendingIntent(conversation);
+                final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mXmppConnectionService);
+                final boolean dismiss_notification = preferences.getBoolean( "dismiss_notification", false);
 				NotificationCompat.Action markReadAction = new NotificationCompat.Action.Builder(
 						R.drawable.ic_drafts_white_24dp,
 						mXmppConnectionService.getString(R.string.mark_as_read),
@@ -403,7 +405,7 @@ public class NotificationService {
 				NotificationCompat.Action replyAction = new NotificationCompat.Action.Builder(
 						R.drawable.ic_send_text_offline,
 						replyLabel,
-						createReplyIntent(conversation, false)).addRemoteInput(remoteInput).build();
+						createReplyIntent(conversation, dismiss_notification)).addRemoteInput(remoteInput).build();
 				NotificationCompat.Action wearReplyAction = new NotificationCompat.Action.Builder(R.drawable.ic_wear_reply,
 						replyLabel,
 						createReplyIntent(conversation, true)).addRemoteInput(remoteInput).build();

--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -5,6 +5,7 @@
     <bool name="enter_is_send">false</bool>
     <bool name="notifications_from_strangers">false</bool>
     <bool name="headsup_notifications">false</bool>
+    <bool name="dismiss_notification">false</bool>
     <bool name="dnd_on_silent_mode">false</bool>
     <bool name="treat_vibrate_as_silent">false</bool>
     <bool name="confirm_messages">true</bool>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -706,7 +706,7 @@
 	<string name="network_is_unreachable">Network is unreachable</string>
 	<string name="certificate_does_not_contain_jid">Certificate does not contain a Jabber ID</string>
 	<string name="server_info_partial">partial</string>
-    <string name="attach_record_video">Record video</string>
+	<string name="attach_record_video">Record video</string>
 	<string name="copy_to_clipboard">Copy to clipboard</string>
 	<string name="message_copied_to_clipboard">Message copied to clipboard</string>
 	<string name="message">Message</string>
@@ -722,17 +722,19 @@
 	<string name="mtm_cert_details">Certificate details:</string>
 	<string name="mtm_notification">Certificate Verification</string>
 	<string name="once">Once</string>
-    <string name="qr_code_scanner_needs_access_to_camera">The QR code scanner needs access to the camera</string>
-    <string name="pref_scroll_to_bottom">Scroll to bottom</string>
+	<string name="qr_code_scanner_needs_access_to_camera">The QR code scanner needs access to the camera</string>
+	<string name="pref_scroll_to_bottom">Scroll to bottom</string>
 	<string name="pref_scroll_to_bottom_summary">Scroll down after sending a message</string>
-    <string name="edit_status_message_title">Edit Status Message</string>
+	<string name="edit_status_message_title">Edit Status Message</string>
 	<string name="edit_status_message">Edit status message</string>
-    <string name="disable_encryption">Disable encryption</string>
+	<string name="disable_encryption">Disable encryption</string>
 	<string name="error_trustkey_general">Conversations is unable to send encrypted messages to %1$s. This may be due to your contact using an outdated server or client that can not handle OMEMO.</string>
 	<string name="error_trustkey_device_list">Unable to fetch device list</string>
 	<string name="error_trustkey_bundle">Unable to fetch device bundles</string>
 	<string name="error_trustkey_hint_mutual">Hint: In some cases this can be fixed by adding each other your contact lists.</string>
 	<string name="disable_encryption_message">Are you sure you want to disable OMEMO encryption for this conversation?\nThis will allow your server administrator to read your messages, but it might be the only way to communicate with people using outdated clients.</string>
 	<string name="disable_now">Disable now</string>
-    <string name="draft">Draft:</string>
+	<string name="draft">Draft:</string>
+	<string name="pref_dismiss_notification">Dismiss notification on reply</string>
+	<string name="pref_dismiss_notification_summary">Sending a reply from the notification will dismiss it</string>
 </resources>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -53,6 +53,12 @@
             android:title="@string/pref_headsup_notifications"
             android:summary="@string/pref_headsup_notifications_summary"/>
         <CheckBoxPreference
+            android:defaultValue="@bool/dismiss_notification"
+            android:dependency="show_notification"
+            android:key="dismiss_notification"
+            android:title="@string/pref_dismiss_notification"
+            android:summary="@string/pref_dismiss_notification_summary"/>
+        <CheckBoxPreference
             android:defaultValue="@bool/vibrate_on_notification"
             android:dependency="show_notification"
             android:key="vibrate_on_notification"


### PR DESCRIPTION
Having to press `mark as read` after I just read and replied to a message kills the whole `quick`  aspect of a quick-reply-thing. 

Also, after reply I find that `mark as read` reacts slower, or even sometimes the notification panel just gets up and I need to pull it down again. (Yes these might be ROM specific though)

This is default off, so you can reply again from the notification, if that's what you desire.

/PS: also some strings were not aligned