### PR TITLE
Fixed trailing slashes in URLs followed by newline

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -123,7 +123,24 @@ public class MessageAdapter extends ArrayAdapter<Message> implements CopyTextVie
 		}
 	}
 
-	private static final Linkify.MatchFilter WEBURL_MATCH_FILTER = (cs, start, end) -> start < 1 || (cs.charAt(start - 1) != '@' && cs.charAt(start - 1) != '.' && !cs.subSequence(Math.max(0, start - 3), start).equals("://"));
+	private static final Linkify.MatchFilter WEBURL_MATCH_FILTER = (cs, start, end) -> {
+		if (start > 0) {
+			if (cs.charAt(start - 1) == '@' || cs.charAt(start - 1) == '.'
+					|| cs.subSequence(Math.max(0, start - 3), start).equals("://")) {
+				return false;
+			}
+		}
+
+		if (end < cs.length()) {
+			// Reject strings that were probably matched only because they contain a dot followed by
+			// by some known TLD (see also comment for WORD_BOUNDARY in Patterns.java)
+			if (Character.isAlphabetic(cs.charAt(end-1)) && Character.isAlphabetic(cs.charAt(end))) {
+				return false;
+			}
+		}
+
+		return true;
+	};
 
 	private static final Linkify.MatchFilter XMPPURI_MATCH_FILTER = (s, start, end) -> {
 		XmppUri uri = new XmppUri(s.subSequence(start, end).toString());

--- a/src/main/java/eu/siacs/conversations/utils/Patterns.java
+++ b/src/main/java/eu/siacs/conversations/utils/Patterns.java
@@ -353,7 +353,6 @@ public class Patterns {
             + "(?:" + PORT_NUMBER + ")?"
             + ")"
             + "(?:" + PATH_AND_QUERY + ")?"
-            + WORD_BOUNDARY
             + ")";
     /**
      * Regular expression to match strings that start with a supported protocol. Rules for domain
@@ -367,7 +366,6 @@ public class Patterns {
             + "(?:" + PORT_NUMBER + ")?"
             + ")"
             + "(?:" + PATH_AND_QUERY + ")?"
-            + WORD_BOUNDARY
             + ")";
     /**
      * Regular expression pattern to match IRIs. If a string starts with http(s):// the expression


### PR DESCRIPTION
The multiline flag is necessary to match a newline as `WORD_BOUNDARY`. Otherwise, a trailing slash is matched by it and is thus not included in the link.

A newline also seems to be added when multiple messages are merged into one bubble, leading to the behaviour described in #2887.