### PR TITLE
add HOST_LOCK parameter to config

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -40,6 +40,8 @@ public final class Config {
 
 
 	public static final String DOMAIN_LOCK = null; //only allow account creation for this domain
+	public static final String HOST_LOCK = null; //set host to fixed value
+	public static final int PORT_LOCK = 5222; //also set port (requires HOST_LOCK != null)
 	public static final String MAGIC_CREATE_DOMAIN = "conversations.im";
 	public static final boolean DISALLOW_REGISTRATION_IN_UI = false; //hide the register checkbox
 

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -205,6 +205,11 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 				}
 			}
 
+			if (Config.HOST_LOCK != null) {
+				hostname = Config.HOST_LOCK;
+				numericPort = Config.PORT_LOCK;
+			}
+
 			if (jid.getLocal() == null) {
 				if (mUsernameMode) {
 					mAccountJidLayout.setError(getString(R.string.invalid_username));
@@ -674,7 +679,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 		}
 		SharedPreferences preferences = getPreferences();
 		mUseTor = Config.FORCE_ORBOT || preferences.getBoolean("use_tor", false);
-		this.mShowOptions = mUseTor || preferences.getBoolean("show_connection_options", false);
+		this.mShowOptions = (mUseTor || preferences.getBoolean("show_connection_options", false)) && (Config.HOST_LOCK == null);
 		this.binding.namePort.setVisibility(mShowOptions ? View.VISIBLE : View.GONE);
 	}
 

--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -278,7 +278,7 @@ public class XmppConnection implements Runnable {
 				} catch (Exception e) {
 					throw new IOException(e.getMessage());
 				}
-			} else if (extended && !account.getHostname().isEmpty()) {
+			} else if ((extended && !account.getHostname().isEmpty()) || (Config.HOST_LOCK != null) ) {
 
 				this.verifiedHostname = account.getHostname();
 


### PR DESCRIPTION
**Supersedes #2766** (see discussion there)

In addition to DOMAIN_LOCK option it can be desireable to also lock hostname and port number. E.g. in managed enironments, where connection parameters are not to be edited by the user.

