### PR TITLE
Make notification channels for api 26+

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/ExportLogsService.java
+++ b/src/main/java/eu/siacs/conversations/services/ExportLogsService.java
@@ -21,6 +21,7 @@ import eu.siacs.conversations.entities.Conversation;
 import eu.siacs.conversations.entities.Message;
 import eu.siacs.conversations.persistance.DatabaseBackend;
 import eu.siacs.conversations.persistance.FileBackend;
+import eu.siacs.conversations.ui.util.NotificationChannelHelper;
 import rocks.xmpp.addr.Jid;
 
 public class ExportLogsService extends Service {
@@ -59,7 +60,8 @@ public class ExportLogsService extends Service {
 		List<Conversation> conversations = mDatabaseBackend.getConversations(Conversation.STATUS_AVAILABLE);
 		conversations.addAll(mDatabaseBackend.getConversations(Conversation.STATUS_ARCHIVED));
 		NotificationManager mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-		NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getBaseContext());
+		NotificationCompat.Builder mBuilder = new NotificationCompat.Builder
+				(getBaseContext(), NotificationChannelHelper.EXPORT_LOGS_NOTIFICATION_CHANNEL_ID);
 		mBuilder.setContentTitle(getString(R.string.notification_export_logs_title))
 				.setSmallIcon(R.drawable.ic_import_export_white_24dp)
 				.setProgress(conversations.size(), 0, false);

--- a/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
@@ -73,6 +73,7 @@ import eu.siacs.conversations.ui.interfaces.OnConversationsListItemUpdated;
 import eu.siacs.conversations.ui.service.EmojiService;
 import eu.siacs.conversations.ui.util.ActivityResult;
 import eu.siacs.conversations.ui.util.MenuDoubleTabUtil;
+import eu.siacs.conversations.ui.util.NotificationChannelHelper;
 import eu.siacs.conversations.ui.util.PendingItem;
 import eu.siacs.conversations.utils.ExceptionHelper;
 import eu.siacs.conversations.xmpp.OnUpdateBlocklist;
@@ -382,6 +383,7 @@ public class ConversationsActivity extends XmppActivity implements OnConversatio
 			pendingViewIntent.push(intent);
 			setIntent(createLauncherIntent(this));
 		}
+		NotificationChannelHelper.createNotificationChannels(this, false);
 	}
 
 	@Override

--- a/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
@@ -37,6 +37,7 @@ import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.services.ExportLogsService;
 import eu.siacs.conversations.services.MemorizingTrustManager;
 import eu.siacs.conversations.ui.util.Color;
+import eu.siacs.conversations.ui.util.NotificationChannelHelper;
 import eu.siacs.conversations.utils.TimeframeUtils;
 import rocks.xmpp.addr.Jid;
 
@@ -374,6 +375,11 @@ public class SettingsActivity extends XmppActivity implements
 				TREAT_VIBRATE_AS_SILENT,
 				MANUALLY_CHANGE_PRESENCE,
 				BROADCAST_LAST_ACTIVITY);
+		final List<String> recreateChannels = Arrays.asList(
+				"notification_ringtone",
+				"vibrate_on_notification",
+				"led",
+				"notification_headsup");
 		if (name.equals(OMEMO_SETTING)) {
 			OmemoSetting.load(this, preferences);
 			changeOmemoSettingSummary();
@@ -398,8 +404,9 @@ public class SettingsActivity extends XmppActivity implements
 			if (this.mTheme != theme) {
 				recreate();
 			}
+		} else if (recreateChannels.contains(name)) {
+			NotificationChannelHelper.createNotificationChannels(this, true);
 		}
-
 	}
 
 	@Override

--- a/src/main/java/eu/siacs/conversations/ui/util/NotificationChannelHelper.java
+++ b/src/main/java/eu/siacs/conversations/ui/util/NotificationChannelHelper.java
@@ -1,0 +1,137 @@
+package eu.siacs.conversations.ui.util;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.media.AudioAttributes;
+import android.net.Uri;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.support.annotation.RequiresApi;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
+
+import eu.siacs.conversations.Config;
+import eu.siacs.conversations.R;
+import eu.siacs.conversations.services.NotificationService;
+
+public class NotificationChannelHelper {
+
+    private static final String CONVERSATION_NOTIFICATION_SHARED_PREF_NAME = "conversation_notif_shared_pref_name";
+    private static final String CONVERSATION_NOTIFICATION_SHARED_PREF = "conversation_notif_shared_pref";
+    private static final String CONVERSATION_QUIET_NOTIFICATION_SHARED_PREF = "conversation_quiet_notif_shared_pref";
+
+    private static final String CONVERSATION_NOTIFICATION_CHANNEL_ID = "conversation";
+    private static final String CONVERSATION_CHANNEL_NAME = "Unread Conversations";
+    private static final String CONVERSATION_QUIET_NOTIFICATION_CHANNEL_ID = "quite_conversation";
+    private static final String CONVERSATION_QUIET_CHANNEL_NAME = "Unread Conversations (Quite Hours)";
+
+    public static final String FOREGROUND_NOTIFICATION_CHANNEL_ID = "foreground";
+    private static final String FOREGROUND_CHANNEL_NAME = "Connected Accounts";
+    public static final String UPDATE_ERROR_NOTIFICATION_CHANNEL_ID = "update_error";
+    private static final String UPDATE_ERROR_CHANNEL_NAME = "Errors";
+    public static final String FILE_ADDING_NOTIFICATION_CHANNEL_ID = "adding_file";
+    private static final String FILE_ADDING_CHANNEL_NAME = "Video Compressing Updates";
+    public static final String EXPORT_LOGS_NOTIFICATION_CHANNEL_ID = "exporting_logs";
+    private static final String EXPORT_LOGS_CHANNEL_NAME = "Logs Export Updates";
+
+    public static void createNotificationChannels(Context context, boolean delete) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            createConversationNotificationChannel(context, false, delete);
+            createConversationNotificationChannel(context, true, delete);
+            createNotificationChannel(context, FOREGROUND_NOTIFICATION_CHANNEL_ID, FOREGROUND_CHANNEL_NAME);
+            createNotificationChannel(context, UPDATE_ERROR_NOTIFICATION_CHANNEL_ID, UPDATE_ERROR_CHANNEL_NAME);
+            createNotificationChannel(context, FILE_ADDING_NOTIFICATION_CHANNEL_ID, FILE_ADDING_CHANNEL_NAME);
+            createNotificationChannel(context, EXPORT_LOGS_NOTIFICATION_CHANNEL_ID, EXPORT_LOGS_CHANNEL_NAME);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private static void createNotificationChannel(Context context, String channelId, String channelName) {
+        NotificationChannel defaultChannel = new NotificationChannel(channelId,
+                channelName, NotificationManager.IMPORTANCE_DEFAULT);
+        NotificationManager mNotifyManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (mNotifyManager == null) {
+            return;
+        }
+        switch(channelId) {
+            case FOREGROUND_NOTIFICATION_CHANNEL_ID:
+                defaultChannel.setImportance(Config.SHOW_CONNECTED_ACCOUNTS ? NotificationManager.IMPORTANCE_DEFAULT : NotificationManager.IMPORTANCE_LOW);
+                break;
+            case UPDATE_ERROR_NOTIFICATION_CHANNEL_ID:
+                defaultChannel.setImportance(NotificationManager.IMPORTANCE_LOW);
+                break;
+        }
+        mNotifyManager.createNotificationChannel(defaultChannel);
+    }
+
+    public static String getPreviousNotificationChannelId(Context context, boolean isQuiet) {
+        String key = !isQuiet ? CONVERSATION_NOTIFICATION_SHARED_PREF : CONVERSATION_QUIET_NOTIFICATION_SHARED_PREF;
+        SharedPreferences sharedPref = context.getSharedPreferences(CONVERSATION_NOTIFICATION_SHARED_PREF_NAME, Context.MODE_PRIVATE);
+        return sharedPref.getString(key, null);
+    }
+
+    private static void getNextNotificationChannelId(Context context, boolean isQuiet) {
+        SharedPreferences sharedPref = context.getSharedPreferences(CONVERSATION_NOTIFICATION_SHARED_PREF_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPref.edit();
+        String key = !isQuiet ? CONVERSATION_NOTIFICATION_SHARED_PREF : CONVERSATION_QUIET_NOTIFICATION_SHARED_PREF;
+        String value = generateNextNotificationChannelId(context, isQuiet);
+        editor.putString(key, value);
+        editor.apply();
+    }
+
+    private static String generateNextNotificationChannelId(Context context, boolean isQuiet) {
+        if (getPreviousNotificationChannelId(context, isQuiet) == null) {
+            return !isQuiet ? CONVERSATION_NOTIFICATION_CHANNEL_ID : CONVERSATION_QUIET_NOTIFICATION_CHANNEL_ID;
+        }
+        return getPreviousNotificationChannelId(context, isQuiet) + Integer.toString(1);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private static void createConversationNotificationChannel(Context context, boolean isQuiet, boolean delete) {
+        NotificationManager mNotifyManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (mNotifyManager == null) {
+            return;
+        }
+        if (getPreviousNotificationChannelId(context, isQuiet) == null) {
+            getNextNotificationChannelId(context, isQuiet);
+        }
+        if (delete) {
+            mNotifyManager.deleteNotificationChannel(getPreviousNotificationChannelId(context, isQuiet));
+            getNextNotificationChannelId(context, isQuiet);
+        }
+        String channelId = getPreviousNotificationChannelId(context, isQuiet);
+        String channelName = !isQuiet ? CONVERSATION_CHANNEL_NAME : CONVERSATION_QUIET_CHANNEL_NAME;
+        NotificationChannel defaultChannel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_DEFAULT);
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        final Resources resources = context.getResources();
+        final String ringtone = preferences.getString("notification_ringtone", resources.getString(R.string.notification_ringtone));
+        final boolean vibrate = preferences.getBoolean("vibrate_on_notification", resources.getBoolean(R.bool.vibrate_on_notification));
+        final boolean led = preferences.getBoolean("led", resources.getBoolean(R.bool.led));
+        final boolean headsup = preferences.getBoolean("notification_headsup", resources.getBoolean(R.bool.headsup_notifications));
+        if (!isQuiet) {
+            if (vibrate) {
+                final int dat = 70;
+                final long[] pattern = {0, 3 * dat, dat, dat};
+                defaultChannel.setVibrationPattern(pattern);
+            } else {
+                defaultChannel.setVibrationPattern(new long[]{0});
+            }
+            Uri uri = Uri.parse(ringtone);
+            try {
+                defaultChannel.setSound(NotificationService.fixRingtoneUri(context, uri),
+                        new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_NOTIFICATION_COMMUNICATION_INSTANT).setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED).build());
+            } catch (SecurityException e) {
+                Log.d(Config.LOGTAG, "unable to use custom notification sound " + uri.toString());
+            }
+            defaultChannel.setImportance(headsup ? NotificationManager.IMPORTANCE_HIGH : NotificationManager.IMPORTANCE_DEFAULT);
+        }
+        defaultChannel.setLightColor(ContextCompat.getColor(context, R.color.primary500));
+        if (led) {
+            defaultChannel.enableLights(true);
+        }
+        mNotifyManager.createNotificationChannel(defaultChannel);
+    }
+}


### PR DESCRIPTION
This pull request aims to solve #2875. This is done in continuation of #2831. It tries to divide all the notifications shown in the app into categories and channels are thus formed based on these categories.