### PR TITLE
Add possibility to delete an avatar

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Account.java
+++ b/src/main/java/eu/siacs/conversations/entities/Account.java
@@ -592,6 +592,10 @@ public class Account extends AbstractEntity {
 		return null;
 	}
 
+	public void removeAvatar() {
+		this.avatar = null;
+	}
+
 	public boolean setAvatar(final String filename) {
 		if (this.avatar != null && this.avatar.equals(filename)) {
 			return false;

--- a/src/main/java/eu/siacs/conversations/entities/Contact.java
+++ b/src/main/java/eu/siacs/conversations/entities/Contact.java
@@ -399,6 +399,10 @@ public class Contact implements ListItem, Blockable {
 				another.getDisplayName());
 	}
 
+	public void removeAvatar() {
+		this.avatar = null;
+	}
+
 	public String getServer() {
 		return getJid().getDomain();
 	}

--- a/src/main/java/eu/siacs/conversations/generator/IqGenerator.java
+++ b/src/main/java/eu/siacs/conversations/generator/IqGenerator.java
@@ -140,15 +140,17 @@ public class IqGenerator extends AbstractGenerator {
 
 	public IqPacket publishAvatarMetadata(final Avatar avatar) {
 		final Element item = new Element("item");
-		item.setAttribute("id", avatar.sha1sum);
 		final Element metadata = item
 			.addChild("metadata", "urn:xmpp:avatar:metadata");
-		final Element info = metadata.addChild("info");
-		info.setAttribute("bytes", avatar.size);
-		info.setAttribute("id", avatar.sha1sum);
-		info.setAttribute("height", avatar.height);
-		info.setAttribute("width", avatar.height);
-		info.setAttribute("type", avatar.type);
+		if (avatar != null) {
+			item.setAttribute("id", avatar.sha1sum);
+			final Element info = metadata.addChild("info");
+			info.setAttribute("bytes", avatar.size);
+			info.setAttribute("id", avatar.sha1sum);
+			info.setAttribute("height", avatar.height);
+			info.setAttribute("width", avatar.height);
+			info.setAttribute("type", avatar.type);
+		}
 		return publish("urn:xmpp:avatar:metadata", item);
 	}
 

--- a/src/main/java/eu/siacs/conversations/parser/MessageParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/MessageParser.java
@@ -174,6 +174,26 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
 				} else if (mXmppConnectionService.isDataSaverDisabled()) {
 					mXmppConnectionService.fetchAvatar(account, avatar);
 				}
+			} else if (Avatar.isAvatarDisableRequest(items)) {
+				if (account.getJid().asBareJid().equals(from)) {
+					if (account.getAvatar() != null) {
+						mXmppConnectionService.getFileBackend().delete(account.getAvatar());
+						account.removeAvatar();
+						mXmppConnectionService.databaseBackend.updateAccount(account);
+						mXmppConnectionService.getAvatarService().clear(account);
+						mXmppConnectionService.updateConversationUi();
+						mXmppConnectionService.updateAccountUi();
+					}
+				} else {
+					Contact contact = account.getRoster().getContact(from);
+					if (contact.getAvatar() != null) {
+						mXmppConnectionService.getFileBackend().delete(contact.getAvatar());
+						contact.removeAvatar();
+						mXmppConnectionService.getAvatarService().clear(contact);
+						mXmppConnectionService.updateConversationUi();
+						mXmppConnectionService.updateRosterUi();
+					}
+				}
 			}
 		} else if ("http://jabber.org/protocol/nick".equals(node)) {
 			final Element i = items.findChild("item");

--- a/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
@@ -663,6 +663,20 @@ public class FileBackend {
 		return file.exists();
 	}
 
+	private boolean isAvatarCached(String avatar) {
+		File file = new File(getAvatarPath(avatar));
+		return file.exists();
+	}
+
+	public boolean delete(String avatar) {
+		File file;
+		if (isAvatarCached(avatar)) {
+			file = new File(getAvatarPath(avatar));
+			file.delete();
+		}
+		return true;
+	}
+
 	public boolean save(Avatar avatar) {
 		File file;
 		if (isAvatarCached(avatar)) {

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -2748,6 +2748,29 @@ public class XmppConnectionService extends Service {
 
 	}
 
+	public void removeAvatar(Account account, final String avatar, final UiCallback<String> callback) {
+		getFileBackend().delete(avatar);
+		final IqPacket packet = XmppConnectionService.this.mIqGenerator.publishAvatarMetadata(null);
+		sendIqPacket(account, packet, new OnIqPacketReceived() {
+			@Override
+			public void onIqPacketReceived(Account account, IqPacket result) {
+				if (result.getType() == IqPacket.TYPE.RESULT) {
+					account.removeAvatar();
+					getAvatarService().clear(account);
+					databaseBackend.updateAccount(account);
+					Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": disabled avatar");
+					if (callback != null) {
+						callback.success(avatar);
+					}
+				} else {
+					if (callback != null) {
+						callback.error(R.string.error_disable_avatar_server_reject, avatar);
+					}
+				}
+			}
+		});
+	}
+
 	public void publishAvatar(Account account, final Avatar avatar, final UiCallback<Avatar> callback) {
 		IqPacket packet = this.mIqGenerator.publishAvatar(avatar);
 		this.sendIqPacket(account, packet, new OnIqPacketReceived() {

--- a/src/main/java/eu/siacs/conversations/ui/PublishProfilePictureActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/PublishProfilePictureActivity.java
@@ -90,6 +90,33 @@ public class PublishProfilePictureActivity extends XmppActivity implements XmppC
 		}
 	};
 
+	private UiCallback<String> avatarDisable = new UiCallback<String>() {
+
+		@Override
+		public void success(String object) {
+			runOnUiThread(() -> {
+				Toast.makeText(PublishProfilePictureActivity.this,
+						R.string.avatar_has_been_disabled,
+						Toast.LENGTH_SHORT).show();
+				finish();
+			});
+		}
+
+		@Override
+		public void error(final int errorCode, String object) {
+			runOnUiThread(() -> {
+				hintOrWarning.setText(errorCode);
+				hintOrWarning.setTextColor(getWarningTextColor());
+				hintOrWarning.setVisibility(View.VISIBLE);
+			});
+
+		}
+
+		@Override
+		public void userInputRequried(PendingIntent pi, String object) {
+		}
+	};
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -154,6 +181,12 @@ public class PublishProfilePictureActivity extends XmppActivity implements XmppC
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
 		getMenuInflater().inflate(R.menu.publish_avatar, menu);
+		final MenuItem removeImage = menu.findItem(R.id.action_remove_image);
+		if (this.account != null && this.account.getAvatar() != null) {
+			removeImage.setVisible(true);
+		} else {
+			removeImage.setVisible(false);
+		}
 		return super.onCreateOptionsMenu(menu);
 	}
 
@@ -164,10 +197,14 @@ public class PublishProfilePictureActivity extends XmppActivity implements XmppC
 				chooseAvatar(true);
 			}
 			return true;
+		} else if (item.getItemId() == R.id.action_remove_image) {
+			xmppConnectionService.removeAvatar(this.account, account.getAvatar(), avatarDisable);
+			return true;
 		} else {
 			return super.onOptionsItemSelected(item);
 		}
 	}
+
 
 	@Override
 	protected void onActivityResult(int requestCode, int resultCode, final Intent data) {
@@ -219,6 +256,7 @@ public class PublishProfilePictureActivity extends XmppActivity implements XmppC
 	protected void onBackendConnected() {
 		this.account = extractAccount(getIntent());
 		if (this.account != null) {
+			invalidateOptionsMenu();
 			reloadAvatar();
 		}
 	}
@@ -300,6 +338,7 @@ public class PublishProfilePictureActivity extends XmppActivity implements XmppC
 	public void refreshUiReal() {
 		if (this.account != null) {
 			reloadAvatar();
+			invalidateOptionsMenu();
 		}
 	}
 

--- a/src/main/java/eu/siacs/conversations/xmpp/pep/Avatar.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/pep/Avatar.java
@@ -72,6 +72,19 @@ public class Avatar {
 		return null;
 	}
 
+	public static boolean isAvatarDisableRequest(Element items) {
+		Element item = items.findChild("item");
+		if (item == null) {
+			return false;
+		}
+		Element metadata = item.findChild("metadata");
+		if (metadata == null) {
+			return false;
+		}
+		String primaryId = item.getAttribute("id");
+		return primaryId != null && metadata.getChildren().size() == 0;
+	}
+
 	@Override
 	public boolean equals(Object object) {
 		if (object != null && object instanceof Avatar) {

--- a/src/main/res/menu/publish_avatar.xml
+++ b/src/main/res/menu/publish_avatar.xml
@@ -6,4 +6,9 @@
         app:showAsAction="always"
         android:icon="@drawable/ic_crop_white_24dp"
         android:title="@string/select_image_and_crop"/>
+    <item
+        android:id="@+id/action_remove_image"
+        app:showAsAction="always"
+        android:icon="@drawable/ic_delete_white_24dp"
+        android:title="@string/remove_image"/>
 </menu>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -247,6 +247,7 @@
 	<string name="touch_to_choose_picture">Touch avatar to select picture from gallery</string>
 	<string name="publishing">Publishing…</string>
 	<string name="error_publish_avatar_server_reject">The server rejected your publication</string>
+	<string name="error_disable_avatar_server_reject">The server rejected your request</string>
 	<string name="error_publish_avatar_converting">Something went wrong while converting your picture</string>
 	<string name="error_saving_avatar">Could not save avatar to disk</string>
 	<string name="or_long_press_for_default">(Or long press to bring back default)</string>
@@ -427,6 +428,7 @@
 	<string name="disable_foreground_service">Disable foreground service</string>
 	<string name="touch_to_open_conversations">Touch to open Conversations</string>
 	<string name="avatar_has_been_published">Avatar has been published!</string>
+	<string name="avatar_has_been_disabled">Avatar has been disabled!</string>
 	<string name="sending_x_file">Sending %s</string>
 	<string name="offering_x_file">Offering %s</string>
 	<string name="hide_offline">Hide offline</string>
@@ -552,6 +554,7 @@
 	<string name="send_corrected_message">Send corrected message</string>
 	<string name="no_keys_just_confirm">You already trust this contact. By selecting \'done\' you are just confirming that %s is part of this group chat.</string>
 	<string name="select_image_and_crop">Select image and crop</string>
+	<string name="remove_image">Remove Image</string>
 	<string name="this_account_is_disabled">You have disabled this account</string>
 	<string name="security_error_invalid_file_access">Security error: Invalid file access</string>
 	<string name="no_application_to_share_uri">No application found to share URI</string>


### PR DESCRIPTION
This pull request tries to solve #1900. It tries to do so by following the manner stated in XEP 0084. A simple delete button is added in `PublishProfilePicture` activity in case the user has a profile picture. On clicking it, an empty `metadata` node is published.