### PR TITLE
Add swiperefreshlayout to load more messages

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/MessageArchiveService.java
+++ b/src/main/java/eu/siacs/conversations/services/MessageArchiveService.java
@@ -178,7 +178,9 @@ public class MessageArchiveService implements OnAdvancedStreamFeaturesLoaded {
 				} else if (p.getType() == IqPacket.TYPE.RESULT && fin != null) {
 					processFin(query, fin);
 				} else if (p.getType() == IqPacket.TYPE.RESULT && query.isLegacy()) {
-					//do nothing
+					if (query.hasCallback()) {
+						query.callback.dismissRefreshLayout();
+					}
 				} else {
 					Log.d(Config.LOGTAG, a.getJid().asBareJid().toString() + ": error executing mam: " + p.toString());
 					finalizeQuery(query, true);
@@ -187,6 +189,9 @@ public class MessageArchiveService implements OnAdvancedStreamFeaturesLoaded {
 		} else {
 			synchronized (this.pendingQueries) {
 				this.pendingQueries.add(query);
+			}
+			if (query.hasCallback()) {
+				query.callback.dismissRefreshLayout();
 			}
 		}
 	}

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -1531,6 +1531,7 @@ public class XmppConnectionService extends Service {
 		if (XmppConnectionService.this.getMessageArchiveService().queryInProgress(conversation, callback)) {
 			return;
 		} else if (timestamp == 0) {
+			callback.dismissRefreshLayout();
 			return;
 		}
 		Log.d(Config.LOGTAG, "load more messages for " + conversation.getName() + " prior to " + MessageGenerator.getTimestamp(timestamp));
@@ -1557,9 +1558,13 @@ public class XmppConnectionService extends Service {
 						callback.informUser(R.string.fetching_history_from_server);
 					} else {
 						callback.informUser(R.string.not_fetching_history_retention_period);
+						callback.dismissRefreshLayout();
 					}
-
+				} else {
+					callback.dismissRefreshLayout();
 				}
+			} else {
+				callback.dismissRefreshLayout();
 			}
 		};
 		mDatabaseReaderExecutor.execute(runnable);
@@ -3828,6 +3833,8 @@ public class XmppConnectionService extends Service {
 		void onMoreMessagesLoaded(int count, Conversation conversation);
 
 		void informUser(int r);
+
+		void dismissRefreshLayout();
 	}
 
 	public interface OnAccountPasswordChanged {

--- a/src/main/res/layout/fragment_conversation.xml
+++ b/src/main/res/layout/fragment_conversation.xml
@@ -8,21 +8,27 @@
         android:layout_height="match_parent"
         android:background="?attr/color_background_secondary">
 
-        <ListView
-            android:id="@+id/messages_view"
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_above="@+id/snackbar"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentTop="true"
-            android:background="?attr/color_background_secondary"
-            android:divider="@null"
-            android:dividerHeight="0dp"
-            android:listSelector="@android:color/transparent"
-            android:stackFromBottom="true"
-            android:transcriptMode="normal"
-            tools:listitem="@layout/message_sent">
-        </ListView>
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true">
+
+            <ListView
+                android:id="@+id/messages_view"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/color_background_secondary"
+                android:divider="@null"
+                android:dividerHeight="0dp"
+                android:listSelector="@android:color/transparent"
+                android:stackFromBottom="true"
+                android:transcriptMode="normal"
+                tools:listitem="@layout/message_sent">
+            </ListView>
+        </android.support.v4.widget.SwipeRefreshLayout>
 
         <android.support.design.widget.FloatingActionButton
             android:id="@+id/scroll_to_bottom_button"
@@ -30,7 +36,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="12dp"
             android:layout_alignParentEnd="true"
-            android:layout_alignBottom="@+id/messages_view"
+            android:layout_alignBottom="@+id/swipe_refresh"
             android:alpha="0.85"
             app:backgroundTint="?attr/color_background_primary"
             android:src="?attr/icon_scroll_down"


### PR DESCRIPTION
This pull request tries to solve #2346. A `swiperefreshlayout` is added to explicitly load old messages as well. 