### PR TITLE
WelcomeActivity must not be invoked if MAGIC_CREATE_DOMAIN == null

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -312,7 +312,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
 			xmppConnectionService.deleteAccount(mAccount);
 		}
 
-		if (xmppConnectionService.getAccounts().size() == 0) {
+		if (xmppConnectionService.getAccounts().size() == 0 && Config.MAGIC_CREATE_DOMAIN != null) {
 			Intent intent = new Intent(EditAccountActivity.this, WelcomeActivity.class);
 			WelcomeActivity.addInviteUri(intent, getIntent());
 			startActivity(intent);

--- a/src/main/java/eu/siacs/conversations/ui/UriHandlerActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/UriHandlerActivity.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 
 import java.util.List;
 
+import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
 import eu.siacs.conversations.persistance.DatabaseBackend;
 import eu.siacs.conversations.utils.XmppUri;
@@ -89,7 +90,7 @@ public class UriHandlerActivity extends AppCompatActivity {
 			return;
 		}
 
-		if (accounts.size() == 0) {
+		if (accounts.size() == 0 && Config.MAGIC_CREATE_DOMAIN != null) {
 			intent = new Intent(getApplicationContext(), WelcomeActivity.class);
 			WelcomeActivity.addInviteUri(intent, xmppUri);
 			startActivity(intent);


### PR DESCRIPTION
This PR prevents WelcomeActivity from being invoked if MAGIC_CREATE_DOMAIN == null.

Supersedes https://github.com/siacs/Conversations/pull/2940