### PR TITLE
xmpp uri can now update name of jid in roster

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -58,6 +58,8 @@ public final class Config {
 
 	public static final boolean DISABLE_BAN = false; // disables the ability to ban users from rooms
 
+	public static final boolean INVITES_MAY_UPDATE_NAME = false; // should XMPP-URI invites be allowed to update names in the roster?
+
 	public static final int PING_MAX_INTERVAL = 300;
 	public static final int IDLE_PING_INTERVAL = 600; //540 is minimum according to docs;
 	public static final int PING_MIN_INTERVAL = 30;

--- a/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
@@ -799,6 +799,11 @@ public class StartConversationActivity extends XmppActivity implements XmppConne
 				if (invite.account != null) {
 					xmppConnectionService.getShortcutService().report(contact);
 				}
+				if (Config.INVITES_MAY_UPDATE_NAME && invite.getName() != null) {
+					contact.setServerName(invite.getName());
+					xmppConnectionService.pushContactToServer(contact);
+				}
+
 				switchToConversation(contact, invite.getBody());
 			}
 			return true;


### PR DESCRIPTION
This is a followup to https://github.com/siacs/Conversations/pull/2791.

XEP-0147 defines URIs for roster actions with name e.g. xmpp:romeo@montague.net?roster;name=Romeo%20Montague

Up to now Conversations will use the name from the URI to update the serverName only if the jid is new (i.e. not in the user's roster).

This PR will allow the user to push the name from the URI to the roster even if the jid is already known. This behaviour must be activated by setting `INVITES_MAY_UPDATE_NAME`  to `true` in `Config.java`.