### PR TITLE
disable the ability to ban users from chat rooms in Config.java

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -52,6 +52,8 @@ public final class Config {
 
 	public static final boolean ALWAYS_NOTIFY_BY_DEFAULT = false;
 
+	public static final boolean DISABLE_BAN = false; // disables the ability to ban users from rooms
+
 	public static final int PING_MAX_INTERVAL = 300;
 	public static final int IDLE_PING_INTERVAL = 600; //540 is minimum according to docs;
 	public static final int PING_MIN_INTERVAL = 30;

--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -377,9 +377,13 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
 						} else {
 							removeMembership.setVisible(true);
 						}
-						banFromConference.setVisible(true);
+						if (!Config.DISABLE_BAN) {
+							banFromConference.setVisible(true);
+						}
 					} else {
-						removeFromRoom.setVisible(true);
+						if (!Config.DISABLE_BAN || mConversation.getMucOptions().membersOnly()) {
+							removeFromRoom.setVisible(true);
+						}
 					}
 					if (user.getAffiliation() != MucOptions.Affiliation.ADMIN) {
 						giveAdminPrivileges.setVisible(true);


### PR DESCRIPTION
As users can be banned from a chat room in Conversations but cannot be unbanned, it might be desirable to entirely turn off the ability to ban users.
This pull request allows to do that in Config.java.