### PR TITLE
pep-bookmarks can be enabled in Config.java

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -109,6 +109,8 @@ public final class Config {
 
 	public static final boolean IGNORE_ID_REWRITE_IN_MUC = true;
 
+	public static final boolean PEP_BOOKMARKS = false; // store and retrieve bookmarks to/from pep instead of private storage
+
 	public static final long MAM_MAX_CATCHUP =  MILLISECONDS_IN_DAY * 5;
 	public static final int MAM_MAX_MESSAGES = 750;
 

--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -1755,7 +1755,7 @@ public class XmppConnection implements Runnable {
 		}
 
 		public boolean bookmarksConversion() {
-			return hasDiscoFeature(account.getJid().asBareJid(),Namespace.BOOKMARKS_CONVERSION) && pepPublishOptions();
+			return (Config.PEP_BOOKMARKS || hasDiscoFeature(account.getJid().asBareJid(),Namespace.BOOKMARKS_CONVERSION)) && pepPublishOptions();
 		}
 
 		public boolean blocking() {


### PR DESCRIPTION
As iNPUTmice now included support for pep-bookmarks in Conversations Master this PR is reduced to the possibility to enable it in Config.java even if there's no conversion-service in place.

----- __outdated description follows__ for the sake of documentation ------

The goal of this PR is to make Conversations compatible with converse.js regarding MUC bookmarks. Today it is not, because Conversations stores bookmarks in private XML (XEP-0049) and converse.js in a PEP node (XEP-0223), which is the reccomended way according to XEP-0048.

If you apply this PR and set PEP_BOOKMARKS=true in Config.java then Conversations will only use PEP for storage of bookmarks and process incoming bookmark events.

**Update:** I believe this PR is now safe. In its original version it would have made Conversations prone to CVE-2018-6591. Read about it here: https://gultsch.de/converse_bookmarks.html. Thanks to iNPUTmice for the hint on how to fix that. As a general downside, if you use this with a server that does not implement and announce publish options as a feature, no bookmarks are published at all.

However it is useable with servers that do and compatibility with other clients using pep bookmarks (e.g. converse.js) is improved.