### PR TITLE
Extend QR scanner to support VCard with IMPP field

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/UriHandlerActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/UriHandlerActivity.java
@@ -12,6 +12,8 @@ import android.net.Uri;
 import android.widget.Toast;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
@@ -153,12 +155,20 @@ public class UriHandlerActivity extends AppCompatActivity {
 		finish();
 	}
 
+	private static final Pattern VCARD_XMPP_PATTERN = Pattern.compile("\nIMPP([^:]*):(xmpp:.+)\n");
+
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, Intent intent) {
 		super.onActivityResult(requestCode, requestCode, intent);
 		if (requestCode == REQUEST_SCAN_QR_CODE && resultCode == RESULT_OK) {
 			String result = intent.getStringExtra(ScanActivity.INTENT_EXTRA_RESULT);
 			if (result != null) {
+				if (result.startsWith("BEGIN:VCARD\n")) {
+					Matcher matcher = VCARD_XMPP_PATTERN.matcher(result);
+					if (matcher.find()) {
+						result = matcher.group(2);
+					}
+				}
 				Uri uri = Uri.parse(result);
 				handleUri(uri, true);
 			}


### PR DESCRIPTION
Currently QR scanner supports only URIs. VCard specification allows
embedding instant messaging protocols in the [`IMPP` field][0].

This change will extract the first XMPP URI from `IMPP` field if a VCard
has been scanned and process it just like if the XMPP URI was scanned
directly. In case the contact is not already present in the roster this
will pop up "Add contact" window.

Example VCard with this URI:

    BEGIN:VCARD
    FN:Test Contact
    EMAIL:test@example.com
    IMPP:xmpp:test@example.com
    END:VCARD

[0]: https://tools.ietf.org/html/rfc6350#section-6.4.3