### PR TITLE
Make nickname matching case-sensitive

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -710,7 +710,7 @@ public class NotificationService {
 	}
 
 	public static Pattern generateNickHighlightPattern(final String nick) {
-		return Pattern.compile("(?<=(^|\\s))" + Pattern.quote(nick) + "\\b", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+		return Pattern.compile("(?<=(^|\\s))" + Pattern.quote(nick) + "\\b");
 	}
 
 	public void setOpenConversation(final Conversation conversation) {


### PR DESCRIPTION
Nicknames are case-sensitive.Perform case-sensitive matching for highlighting the own nickname in MUC messages and while checking whether to notify.