### PR TITLE
move enabling of foreign key support to onConfigure

### DIFF
--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -188,8 +188,12 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 	}
 
 	@Override
+	public void onConfigure(SQLiteDatabase db) {
+		db.execSQL("PRAGMA foreign_keys=ON");
+	}
+
+	@Override
 	public void onCreate(SQLiteDatabase db) {
-		db.execSQL("PRAGMA foreign_keys=ON;");
 		db.execSQL("create table " + Account.TABLENAME + "(" + Account.UUID + " TEXT PRIMARY KEY,"
 				+ Account.USERNAME + " TEXT,"
 				+ Account.SERVER + " TEXT,"
@@ -846,13 +850,6 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 		String[] args = {account.getUuid()};
 		final int rows = db.delete(Account.TABLENAME, Account.UUID + "=?", args);
 		return rows == 1;
-	}
-
-	@Override
-	public SQLiteDatabase getWritableDatabase() {
-		SQLiteDatabase db = super.getWritableDatabase();
-		db.execSQL("PRAGMA foreign_keys=ON;");
-		return db;
 	}
 
 	public boolean updateMessage(Message message, boolean includeBody) {


### PR DESCRIPTION
This way we avoid repeating the code. Unlike `getWritableDatabase`, `onConfigure` is intended to be overridden.

In fact, `onConfigure` documentation specifically says: "Called when the database connection is being configured, to enable features such as write-ahead logging or *foreign key support*."