### PR TITLE
explicitly set secure_delete pragma for SQLite database

### DIFF
--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -190,6 +190,7 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 	@Override
 	public void onConfigure(SQLiteDatabase db) {
 		db.execSQL("PRAGMA foreign_keys=ON");
+		db.execSQL("PRAGMA secure_delete=ON");
 	}
 
 	@Override


### PR DESCRIPTION
Conversations stores sensitive data, such as `SQLiteAxolotlStore` tables, in its database.

`secure_delete=ON` is the default for newer Android devices:
https://android-review.googlesource.com/c/platform/external/sqlite/+/209123

However, older devices had it disabled by default, so any database created than has this setting disabled and it will not be updated automatically.

Also, the default might be changed in the future (for example, to `FAST`, added in 2017), so it is safer to set it explicitly.