### PR TITLE
improve active_since implementation (XEP-0319: Last User Interaction in Presence)

### DIFF
--- a/src/main/java/eu/siacs/conversations/parser/PresenceParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/PresenceParser.java
@@ -287,6 +287,9 @@ public class PresenceParser extends AbstractParser implements
 			} else {
 				contact.removePresence(from.getResource());
 			}
+			if (contact.getShownStatus() == Presence.Status.OFFLINE) {
+				contact.flagInactive();
+			}
 			mXmppConnectionService.onContactStatusChanged.onContactStatusChanged(contact, false);
 		} else if (type.equals("subscribe")) {
 			if (contact.getOption(Contact.Options.PREEMPTIVE_GRANT)) {


### PR DESCRIPTION
I recognized that Conversations will not broadcast idle in presence in case it is started and left in background. Reason is mLastActivity being zero.

Therefore other users using Conversations see the contact as being active when in fact it is inactive.

This PR tries to solve this by persisting the last active time stamp and then us this time as idleSince.

Furthermore I recognized that Conversations shows another contact as "currently online" even after it logged off from the xmpp server.

Reason is that Conversations receives a presence of type "unavailable" without any timestamp. In this case the contact stays "active".

I propose to simply check if the contact is entirely offline after a presence of type "unavailable" is received. If it is offline flag it as inactive.