### PR TITLE
discover rooms

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -111,6 +111,12 @@ public final class Config {
 
 	public static final boolean IGNORE_ID_REWRITE_IN_MUC = true;
 
+	public static final Jid MUC_SERVICES_FOR_DISCO[] = {
+		/// Jid.of("conference.mydomain.org")   // List all confernce services you want to query
+	};
+
+	public static final boolean MUC_DISCO_OWN_SERVER = false; // whether to query the MUC services on the account's own server
+
 	public static final long MAM_MAX_CATCHUP =  MILLISECONDS_IN_DAY * 5;
 	public static final int MAM_MAX_MESSAGES = 750;
 

--- a/src/main/java/eu/siacs/conversations/entities/Account.java
+++ b/src/main/java/eu/siacs/conversations/entities/Account.java
@@ -571,6 +571,16 @@ public class Account extends AbstractEntity {
 		return this.bookmarks;
 	}
 
+	public List<Bookmark> getBookmarksToBePushed() {
+		ArrayList<Bookmark> result = new ArrayList<>();
+		for(Bookmark bookmark : bookmarks) {
+			if (bookmark.push()) {
+				result.add(bookmark);
+			}
+		}
+		return result;
+	}
+
 	public void setBookmarks(final CopyOnWriteArrayList<Bookmark> bookmarks) {
 		this.bookmarks = bookmarks;
 	}

--- a/src/main/java/eu/siacs/conversations/entities/Bookmark.java
+++ b/src/main/java/eu/siacs/conversations/entities/Bookmark.java
@@ -20,6 +20,15 @@ public class Bookmark extends Element implements ListItem {
 	private Account account;
 	private WeakReference<Conversation> conversation;
 	private Jid jid;
+	private boolean push = true;
+
+	public Bookmark(final Account account, final Jid jid, final boolean push) {
+		super("conference");
+		this.jid = jid;
+		this.setAttribute("jid", jid.toString());
+		this.account = account;
+		this.push = push;
+	}
 
 	public Bookmark(final Account account, final Jid jid) {
 		super("conference");
@@ -171,4 +180,13 @@ public class Bookmark extends Element implements ListItem {
 		}
 		return StringUtils.changed(before, name);
 	}
+
+	public boolean push() {
+		return this.push;
+	}
+
+	public void flagPush() {
+		this.push = true;
+	}
+
 }

--- a/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/StartConversationActivity.java
@@ -398,6 +398,7 @@ public class StartConversationActivity extends XmppActivity implements XmppConne
 		bookmark.setConversation(conversation);
 		if (!bookmark.autojoin() && getPreferences().getBoolean("autojoin", getResources().getBoolean(R.bool.autojoin))) {
 			bookmark.setAutojoin(true);
+			bookmark.flagPush();
 			xmppConnectionService.pushBookmarks(bookmark.getAccount());
 		}
 		SoftKeyboardUtils.hideSoftKeyboard(this);


### PR DESCRIPTION
This is a simple solution for https://github.com/siacs/Conversations/issues/279.

In Config.java you can list all muc services you want your client to query for rooms. Each found room that is not already in your list of bookmarks is added to it. 

You can also choose to automatically query the muc services on the account's your own server.