### PR TITLE
add config for automatic downloading of files

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -78,6 +78,8 @@ public final class Config {
 	public static final Bitmap.CompressFormat IMAGE_FORMAT = Bitmap.CompressFormat.JPEG;
 	public static final int IMAGE_QUALITY = 75;
 
+	public static final boolean AUTO_ACCEPT_ALL_FILES = false; // dangerous. setting this to true might expose your IP to strangers and download malicious content
+
 	public static final int MESSAGE_MERGE_WINDOW = 20;
 
 	public static final int PAGE_SIZE = 50;

--- a/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
+++ b/src/main/java/eu/siacs/conversations/crypto/PgpDecryptionService.java
@@ -153,9 +153,8 @@ public class PgpDecryptionService {
 							message.setBody(body);
 							message.setEncryption(Message.ENCRYPTION_DECRYPTED);
 							final HttpConnectionManager manager = mXmppConnectionService.getHttpConnectionManager();
-							if (message.trusted()
-									&& message.treatAsDownloadable()
-									&& manager.getAutoAcceptFileSize() > 0) {
+							if (message.treatAsDownloadable() && (Config.AUTO_ACCEPT_ALL_FILES
+									|| (message.trusted() && manager.getAutoAcceptFileSize() > 0))) {
 								manager.createNewDownloadConnection(message);
 							}
 						} catch (IOException e) {

--- a/src/main/java/eu/siacs/conversations/http/HttpDownloadConnection.java
+++ b/src/main/java/eu/siacs/conversations/http/HttpDownloadConnection.java
@@ -259,7 +259,7 @@ public class HttpDownloadConnection implements Transferable {
 			file.setExpectedSize(size);
 			message.resetFileParams();
 			if (mHttpConnectionManager.hasStoragePermission()
-					&& size <= mHttpConnectionManager.getAutoAcceptFileSize()
+					&& (Config.AUTO_ACCEPT_ALL_FILES || size <= mHttpConnectionManager.getAutoAcceptFileSize())
 					&& mXmppConnectionService.isDataSaverDisabled()) {
 				HttpDownloadConnection.this.acceptedAutomatically = true;
 				download(interactive);

--- a/src/main/java/eu/siacs/conversations/parser/MessageParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/MessageParser.java
@@ -605,7 +605,7 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
 
 			mXmppConnectionService.databaseBackend.createMessage(message);
 			final HttpConnectionManager manager = this.mXmppConnectionService.getHttpConnectionManager();
-			if (message.trusted() && message.treatAsDownloadable() && manager.getAutoAcceptFileSize() > 0) {
+			if (message.treatAsDownloadable() && (Config.AUTO_ACCEPT_ALL_FILES || (message.trusted() && manager.getAutoAcceptFileSize() > 0))) {
 				manager.createNewDownloadConnection(message);
 			} else if (notify) {
 				if (query != null && query.isCatchup()) {

--- a/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
@@ -244,6 +244,13 @@ public class SettingsActivity extends XmppActivity implements
 		if (deleteOmemoPreference != null) {
 			deleteOmemoPreference.setOnPreferenceClickListener(preference -> deleteOmemoIdentities());
 		}
+
+		if (Config.AUTO_ACCEPT_ALL_FILES) {
+			final Preference autoAcceptFileSizePreference = mSettingsFragment.findPreference("auto_accept_file_size");
+			if (autoAcceptFileSizePreference != null) {
+				attachmentsCategory.removePreference(autoAcceptFileSizePreference);
+			}
+		}
 	}
 
 	private void changeOmemoSettingSummary() {

--- a/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleConnection.java
@@ -425,7 +425,7 @@ public class JingleConnection implements Transferable {
 				conversation.add(message);
 				mJingleConnectionManager.updateConversationUi(true);
 				if (mJingleConnectionManager.hasStoragePermission()
-						&& size < this.mJingleConnectionManager.getAutoAcceptFileSize()
+						&& (Config.AUTO_ACCEPT_ALL_FILES || size < this.mJingleConnectionManager.getAutoAcceptFileSize())
 						&& mXmppConnectionService.isDataSaverDisabled()) {
 					Log.d(Config.LOGTAG, "auto accepting file from "+ packet.getFrom());
 					this.acceptedAutomatically = true;


### PR DESCRIPTION
This PR will add a config option that allows for automatic downloading of all received files regardless of size and if you know the sender.

There might be situations where this is wanted. I wouldn't recommend using this in the wild though.
