### PR TITLE
 Set navigation bar color to dark on dark theme 

### DIFF
--- a/src/main/res/values-v21/themes.xml
+++ b/src/main/res/values-v21/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="ConversationsTheme.Dark" parent="ConversationsTheme.Dark.Base">
+        <item name="android:navigationBarColor">@color/grey900</item>
+    </style>
+</resources>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -96,7 +96,9 @@
         <item type="reference" name="icon_enable_undecided_device">@drawable/ic_new_releases_black_24dp</item>
     </style>
 
-    <style name="ConversationsTheme.Dark" parent="Theme.AppCompat.NoActionBar">
+    <style name="ConversationsTheme.Dark" parent="ConversationsTheme.Dark.Base" />
+
+    <style name="ConversationsTheme.Dark.Base" parent="Theme.AppCompat.NoActionBar">
         <item name="colorPrimary">@color/green800</item>
         <item name="colorPrimaryDark">@color/green900</item>
         <item name="colorAccent">@color/blue_a100</item>


### PR DESCRIPTION
This change sets the navigation bar color to secondary background color when using dark theme.

This avoids using default system color for navigation bar that could be white.

Before this change:

![before](https://user-images.githubusercontent.com/1718963/41679913-1009df50-74d0-11e8-964c-a59ea7cb8768.png)

After this change:

![after](https://user-images.githubusercontent.com/1718963/41679926-19ae0888-74d0-11e8-99f5-2fa775d1b669.png)
