### PR TITLE
improve identification of muc service

### DIFF
--- a/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/XmppConnection.java
@@ -1541,6 +1541,7 @@ public class XmppConnection implements Runnable {
 			for (final Entry<Jid, ServiceDiscoveryResult> cursor : disco.entrySet()) {
 				final ServiceDiscoveryResult value = cursor.getValue();
 				if (value.getFeatures().contains("http://jabber.org/protocol/muc")
+						&& value.hasIdentity("conference", "text")
 						&& !value.getFeatures().contains("jabber:iq:gateway")
 						&& !value.hasIdentity("conference", "irc")) {
 					servers.add(cursor.getKey().toString());


### PR DESCRIPTION
According to https://xmpp.org/extensions/xep-0045.html#registrar-discocat 'A Multi-User Chat service or room is identified by the "conference" category and the "text" type within Service Discovery.'.

I added this extra check because Conversations tried to use my ejabberd's push service "p2..." as muc service.