### PR TITLE
Fix auth when upgrading from SCRAM-SHA-1 to -256

### DIFF
--- a/src/main/java/eu/siacs/conversations/crypto/sasl/ScramMechanism.java
+++ b/src/main/java/eu/siacs/conversations/crypto/sasl/ScramMechanism.java
@@ -43,7 +43,7 @@ abstract class ScramMechanism extends SaslMechanism {
 	static {
 		CACHE = new LruCache<String, KeyPair>(10) {
 			protected KeyPair create(final String k) {
-				// Map keys are "bytesToHex(JID),bytesToHex(password),bytesToHex(salt),iterations".
+				// Map keys are "bytesToHex(JID),bytesToHex(password),bytesToHex(salt),iterations,SASL-Mechanism".
 				// Changing any of these values forces a cache miss. `CryptoHelper.bytesToHex()'
 				// is applied to prevent commas in the strings breaking things.
 				final String[] kparts = k.split(",", 4);
@@ -147,12 +147,13 @@ abstract class ScramMechanism extends SaslMechanism {
 				final byte[] authMessage = (clientFirstMessageBare + ',' + new String(serverFirstMessage) + ','
 						+ clientFinalMessageWithoutProof).getBytes();
 
-				// Map keys are "bytesToHex(JID),bytesToHex(password),bytesToHex(salt),iterations".
+				// Map keys are "bytesToHex(JID),bytesToHex(password),bytesToHex(salt),iterations,SASL-Mechanism".
 				final KeyPair keys = CACHE.get(
 						CryptoHelper.bytesToHex(account.getJid().asBareJid().toString().getBytes()) + ","
 						+ CryptoHelper.bytesToHex(account.getPassword().getBytes()) + ","
 						+ CryptoHelper.bytesToHex(salt.getBytes()) + ","
 						+ String.valueOf(iterationCount)
+						+ getMechanism()
 						);
 				if (keys == null) {
 					throw new AuthenticationException("Invalid keys generated");


### PR DESCRIPTION
While working on Metronome's implementation of SCRAM-SHA-256 @maranda spotted a key being sent by Conversations that was an unexpected length. I believe the SCRAM-SHA-1 key was being sent, which caused auth to fail the first time. It then started working (the cache was cleared and a SCRAM-SHA-1 key was generated).

This PR adds the mechanism as a cache parameter so that keys can exist in the cache for both mechanisms without conflicting.

It's been a while since I've touched this, or thought about Java in any serious way so a security review would be appreciated. I believe the only effect is that logins will be a tad slower the first time after this is deployed until the cache warms back up.