### PR TITLE
Lower foreground service notification priority

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -869,7 +869,7 @@ public class NotificationService {
         }
         mBuilder.setContentIntent(createOpenConversationsIntent());
         mBuilder.setWhen(0);
-        mBuilder.setPriority(Notification.PRIORITY_LOW);
+        mBuilder.setPriority(Notification.PRIORITY_MIN);
         mBuilder.setSmallIcon(R.drawable.ic_link_white_24dp);
 
         if (Compatibility.runsTwentySix()) {


### PR DESCRIPTION
...so no useless icon is shown on the status bar on Android 7 and older (as it was up to 2.2.9)