### PR TITLE
New Config-Option: Disable reconnect if unauthorized

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -67,6 +67,7 @@ public final class Config {
 	public static final int CONNECT_TIMEOUT = 90;
 	public static final int CONNECT_DISCO_TIMEOUT = 20;
 	public static final int MINI_GRACE_PERIOD = 750;
+	public static final boolean DISABLE_RECONNECT_IF_UNAUTHORIZED = false;
 
 	public static final boolean XEP_0392 = true; //enables XEP-0392 v0.6.0
 

--- a/src/main/java/eu/siacs/conversations/entities/Account.java
+++ b/src/main/java/eu/siacs/conversations/entities/Account.java
@@ -277,7 +277,8 @@ public class Account extends AbstractEntity {
     public boolean hasErrorStatus() {
         return getXmppConnection() != null
                 && (getStatus().isError() || getStatus() == State.CONNECTING)
-                && getXmppConnection().getAttempt() >= 3;
+                && (getXmppConnection().getAttempt() >= 3 ||
+                    (Config.DISABLE_RECONNECT_IF_UNAUTHORIZED && getStatus() == State.UNAUTHORIZED)) ;
     }
 
     public Presence.Status getPresenceStatus() {

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -368,7 +368,8 @@ public class XmppConnectionService extends Service {
             } else if (account.getStatus() == Account.State.REGISTRATION_SUCCESSFUL) {
                 databaseBackend.updateAccount(account);
                 reconnectAccount(account, true, false);
-            } else if (account.getStatus() != Account.State.CONNECTING && account.getStatus() != Account.State.NO_INTERNET) {
+            } else if (account.getStatus() != Account.State.CONNECTING && account.getStatus() != Account.State.NO_INTERNET &&
+                (!Config.DISABLE_RECONNECT_IF_UNAUTHORIZED || account.getStatus() != Account.State.UNAUTHORIZED)) {
                 resetSendingToWaiting(account);
                 if (connection != null && account.getStatus().isAttemptReconnect()) {
                     final int next = connection.getTimeToNextAttempt();
@@ -3179,13 +3180,14 @@ public class XmppConnectionService extends Service {
 
 	private void reconnectAccount(final Account account, final boolean force, final boolean interactive) {
 		synchronized (account) {
+			Log.d(Config.LOGTAG, "reconnectAccount(account="+account.getJid().asBareJid()+", force="+force+", interactive="+interactive+"); Status="+getString(account.getStatus().getReadableId()));
 			XmppConnection connection = account.getXmppConnection();
 			if (connection == null) {
 				connection = createConnection(account);
 				account.setXmppConnection(connection);
 			}
 			boolean hasInternet = hasInternetConnection();
-			if (account.isEnabled() && hasInternet) {
+			if (account.isEnabled() && hasInternet && (!Config.DISABLE_RECONNECT_IF_UNAUTHORIZED || interactive || account.getStatus() != Account.State.UNAUTHORIZED)) {
 				if (!force) {
 					disconnect(account, false);
 				}


### PR DESCRIPTION
In some scenarios it is undesirable to have Conversations automatically make multiple attempts to reconnect, in case the authorization fails, because this might e.g. trigger a blocking of your account.

Therefore this PR introduces a new config-option `DISABLE_RECONNECT_IF_UNAUTHORIZED`. If set to true, Conversations does not schedule new connection attempts in case e.g. your password is wrong.

Additionally the respective error notification is displayed after the first failed attempt.

