### PR TITLE
fix-3264:fix incomplete message notification displayed on notification drawer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,20 +69,13 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 297
         versionName "2.3.5"
         archivesBaseName += "-$versionName"
         applicationId "eu.siacs.conversations"
         resValue "string", "applicationId", applicationId
         resValue "string", "app_name", "Conversations"
-    }
-
-    lintOptions {
-        checkReleaseBuilds false
-        // Or, if you prefer, you can continue to check for errors in release builds,
-        // but continue the build even when errors are found:
-        abortOnError false
     }
 
     dataBinding {

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,13 @@ android {
         resValue "string", "app_name", "Conversations"
     }
 
+    lintOptions {
+        checkReleaseBuilds false
+        // Or, if you prefer, you can continue to check for errors in release builds,
+        // but continue the build even when errors are found:
+        abortOnError false
+    }
+
     dataBinding {
         enabled true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -69,9 +69,9 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 26
-        versionCode 297
-        versionName "2.3.5"
+        targetSdkVersion 28
+        versionCode 303
+        versionName "2.3.7"
         archivesBaseName += "-$versionName"
         applicationId "eu.siacs.conversations"
         resValue "string", "applicationId", applicationId

--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -640,7 +640,12 @@ public class NotificationService {
         } else {
             if (messages.get(0).getConversation().getMode() == Conversation.MODE_SINGLE) {
                 builder.setStyle(new NotificationCompat.BigTextStyle().bigText(getMergedBodies(messages)));
-                builder.setContentText(UIHelper.getMessagePreview(mXmppConnectionService, messages.get(0)).first);
+//                builder.setContentText(UIHelper.getMessagePreview(mXmppConnectionService, messages.get(0)).first);
+
+                //set the newest message as notification content text and display the number of messages received
+                builder.setContentText(UIHelper.getMessagePreview(mXmppConnectionService, messages.get(messages.size()-1)).first);
+                builder.setNumber(messages.size());
+
             } else {
                 final NotificationCompat.InboxStyle style = new NotificationCompat.InboxStyle();
                 SpannableString styledString;


### PR DESCRIPTION
#3265 Change: complete message notification displayed on the notification drawer to prompt user latest message content and received message count.