### PR TITLE
Add option to block screenshots of the app

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ActionBarActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ActionBarActivity.java
@@ -1,9 +1,14 @@
 package eu.siacs.conversations.ui;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.annotation.BoolRes;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
+import android.view.WindowManager;
 
+import eu.siacs.conversations.R;
 
 public abstract class ActionBarActivity extends AppCompatActivity {
     public static void configureActionBar(ActionBar actionBar) {
@@ -25,5 +30,22 @@ public abstract class ActionBarActivity extends AppCompatActivity {
                 break;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    void initializeScreenshotSecurity() {
+        if (isScreenSecurityEnabled()) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        } else {
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        }
+    }
+    public boolean isScreenSecurityEnabled() {
+        return getBooleanPreference("screen_security", R.bool.screen_security);
+    }
+    protected SharedPreferences getPreferences() {
+        return PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+    }
+    protected boolean getBooleanPreference(String name, @BoolRes int res) {
+        return getPreferences().getBoolean(name, getResources().getBoolean(res));
     }
 }

--- a/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
@@ -820,6 +820,7 @@ public abstract class XmppActivity extends ActionBarActivity {
 	@Override
 	public void onResume() {
 		super.onResume();
+		initializeScreenshotSecurity();
 	}
 
 	protected int findTheme() {

--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -43,4 +43,5 @@
     <bool name="use_share_location_plugin">false</bool>
     <bool name="start_searching">false</bool>
     <string name="video_compression">360</string>
+    <bool name="screen_security">false</bool>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -804,4 +804,6 @@
     <string name="start_orbot">Start Orbot</string>
     <string name="no_market_app_installed">No market app installed.</string>
     <string name="group_chat_will_make_your_jabber_id_public">This group chat will make your Jabber ID public</string>
+    <string name="pref_screen_security_summary">Block screenshots in the recents list and inside the app.</string>
+    <string name="pref_screen_security">Screen security</string>
 </resources>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -232,6 +232,11 @@
                     android:summary="@string/pref_remove_trusted_certificates_summary"
                     android:title="@string/pref_remove_trusted_certificates_title" />
                 <CheckBoxPreference
+                    android:defaultValue="@bool/screen_security"
+                    android:key="screen_security"
+                    android:summary="@string/pref_screen_security_summary"
+                    android:title="@string/pref_screen_security" />
+                <CheckBoxPreference
                     android:defaultValue="@bool/allow_message_correction"
                     android:key="allow_message_correction"
                     android:summary="@string/pref_allow_message_correction_summary"


### PR DESCRIPTION
Fix #1995

Copied from Pix-Art, which looks like it`s based on SilenceIM (implemented years ago in SMSsecure).