### PR TITLE
remove bookmark after a room is destroyed

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -1853,9 +1853,16 @@ public class XmppConnectionService extends Service {
 			if (conversation.getMode() == Conversation.MODE_MULTI) {
 				if (conversation.getAccount().getStatus() == Account.State.ONLINE) {
 					Bookmark bookmark = conversation.getBookmark();
-					if (maySyncronizeWithBookmarks && bookmark != null && bookmark.autojoin() && synchronizeWithBookmarks()) {
-						bookmark.setAutojoin(false);
-						pushBookmarks(bookmark.getAccount());
+					if (maySyncronizeWithBookmarks && bookmark != null && synchronizeWithBookmarks()) {
+						if (conversation.getMucOptions().getError() == MucOptions.Error.DESTROYED) {
+							Account account = bookmark.getAccount();
+							bookmark.setConversation(null);
+							account.getBookmarks().remove(bookmark);
+							pushBookmarks(account);
+						} else if (bookmark.autojoin()) {
+							bookmark.setAutojoin(false);
+							pushBookmarks(bookmark.getAccount());
+						}
 					}
 				}
 				leaveMuc(conversation);


### PR DESCRIPTION
Currently the user is shown a snackbar dialog in case he wants to enter a MUC that has been destroyed before. If the user selects "leave", the conversation will be archived but an existing bookmark will stay.

As the user can very easily recreate the MUC unintentionally by simply selecting the bookmark left I believe it would he desirable to simply remove the bookmark as well.