### PR TITLE
Enable notifications from strangers by default

### DIFF
--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -3,7 +3,7 @@
     <string name="default_resource">Phone</string>
     <bool name="portrait_only">true</bool>
     <bool name="enter_is_send">false</bool>
-    <bool name="notifications_from_strangers">false</bool>
+    <bool name="notifications_from_strangers">true</bool>
     <bool name="headsup_notifications">false</bool>
     <bool name="dnd_on_silent_mode">false</bool>
     <bool name="treat_vibrate_as_silent">false</bool>

--- a/src/quicksy/res/values/defaults.xml
+++ b/src/quicksy/res/values/defaults.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="notifications_from_strangers">true</bool>
 </resources>


### PR DESCRIPTION
Notifications from strangers are disabled by default in order to cope
with spam. On the other hand, this complicates contacting other users
for the first time, which leads to a bad user experience.