### PR TITLE
Fill all media preview slots, if possible

### DIFF
--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -790,11 +790,18 @@ public class DatabaseBackend extends SQLiteOpenHelper {
 		};
 	}
 
-	public List<FilePath> getRelativeFilePaths(String account, Jid jid, int limit) {
+	public List<FilePath> getRelativeFilePaths(String account, Jid jid, int limit, int offset) {
 		SQLiteDatabase db = this.getReadableDatabase();
 		final String SQL = "select uuid,relativeFilePath from messages where type in (1,2) and conversationUuid=(select uuid from conversations where accountUuid=? and (contactJid=? or contactJid like ?)) order by timeSent desc";
 		final String[] args = {account, jid.toEscapedString(), jid.toEscapedString()+"/%"};
-		Cursor cursor = db.rawQuery(SQL+(limit > 0 ? " limit "+String.valueOf(limit) : ""), args);
+		String limitSQL = "";
+		if (limit > 0) {
+			limitSQL += " limit " + String.valueOf(limit);
+			if (offset > 0) {
+				limitSQL += " offset " + String.valueOf(offset);
+			}
+		}
+		Cursor cursor = db.rawQuery(SQL+limitSQL, args);
 		List<FilePath> filesPaths = new ArrayList<>();
 		while(cursor.moveToNext()) {
 			filesPaths.add(new FilePath(cursor.getString(0),cursor.getString(1)));

--- a/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
@@ -44,7 +44,6 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -462,19 +461,16 @@ public class FileBackend {
         }
     }
 
-    public List<Attachment> convertToAttachments(List<DatabaseBackend.FilePath> relativeFilePaths) {
-        List<Attachment> attachments = new ArrayList<>();
-        for(DatabaseBackend.FilePath relativeFilePath : relativeFilePaths) {
-            final String mime = MimeUtils.guessMimeTypeFromExtension(MimeUtils.extractRelevantExtension(relativeFilePath.path));
-            Log.d(Config.LOGTAG,"mime="+mime);
-            File file = getFileForPath(relativeFilePath.path, mime);
-            if (file.exists()) {
-                attachments.add(Attachment.of(relativeFilePath.uuid, file,mime));
-            } else {
-                Log.d(Config.LOGTAG,"file "+file.getAbsolutePath()+" doesnt exist");
-            }
+    public Attachment convertToAttachment(DatabaseBackend.FilePath relativeFilePath) {
+        final String mime = MimeUtils.guessMimeTypeFromExtension(MimeUtils.extractRelevantExtension(relativeFilePath.path));
+        Log.d(Config.LOGTAG,"mime="+mime);
+        File file = getFileForPath(relativeFilePath.path, mime);
+        if (file.exists()) {
+            return Attachment.of(relativeFilePath.uuid, file, mime);
+        } else {
+            Log.d(Config.LOGTAG,"file "+file.getAbsolutePath()+" doesn't exist");
         }
-        return attachments;
+        return null;
     }
 
     private String getConversationsDirectory(final String type) {


### PR DESCRIPTION
All attachments of the conversation will be searched until enough files are found. This avoids empty slots if recent files are no longer present.

In each iteration, three times the number of required paths are fetched from the database. I think this is slightly more efficient than repeatedly querying for a single path, if only one is still needed (e.g. when there are many files deleted in between).

When zero is given as `limit`, all attachments are fetched in the first iteration, as before.

I did not create wrappers with the previous signature for the functions that I had to change (`getRelativeFilePaths()` and `convertToAttachments()`), since these were only used in this single place anyway. I hope this is ok.

This probably fixes #3332.