### PR TITLE
notify only once for multiple incoming messages arriving quickly after one another

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -83,6 +83,8 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
 	private ChatState mOutgoingChatState = Config.DEFAULT_CHATSTATE;
 	private ChatState mIncomingChatState = Config.DEFAULT_CHATSTATE;
 	private String mFirstMamReference = null;
+	private long lastPossibleNotificationTime = 0;
+	private boolean resumed = true;
 
 	public Conversation(final String name, final Account account, final Jid contactJid,
 	                    final int mode) {
@@ -1000,6 +1002,55 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
 	@Override
 	public int getAvatarBackgroundColor() {
 		return UIHelper.getColorForName(getName().toString());
+	}
+
+	/**
+	 * Resets the information about the resumed state of the corresponding
+	 * {@link eu.siacs.conversations.ui.ConversationFragment} object.
+	 */
+	public void resetResumed() {
+		resumed = false;
+	}
+
+	/**
+	 * Informs this conversation about the fact that the corresponding
+	 * {@link eu.siacs.conversations.ui.ConversationFragment} object is resumed.
+	 */
+	public void resumed() {
+		this.resumed = true;
+	}
+
+	/**
+	 * Provides the resumed state of the corresponding
+	 * {@link eu.siacs.conversations.ui.ConversationFragment} object.
+	 * @return true if the {@link eu.siacs.conversations.ui.ConversationFragment} object
+	 * was resumed after the last reset by {@link #resetResumed()} or false otherwise
+	 */
+	public boolean wasResumed() {
+		return resumed;
+	}
+
+	/**
+	 * Provides the time at which the user may have been notified for an incoming message
+	 * but may have not been notified because of another one arriving shortly before.
+	 * This mechanism is done with the help of
+	 * {@link eu.siacs.conversations.services.NotificationService#notifyAgain(Conversation)}
+	 * The time is set by {@link #updateLastPossibleNotificationTime()}.
+	 * @return time at which the user may have been notified for an incoming message
+	 */
+	public long getLastPossibleNotificationTime() {
+		return lastPossibleNotificationTime;
+	}
+
+	/**
+	 * This should only be executed by
+	 * {@link eu.siacs.conversations.services.NotificationService#notifyAgain(Conversation)}
+	 * each time a notification may be triggered.
+	 * Sets the time at which the user may have been notified for an incoming message
+	 * but may have not been notified because of another one arriving shortly before.
+	 */
+	public void updateLastPossibleNotificationTime() {
+		lastPossibleNotificationTime = System.currentTimeMillis();
 	}
 
 	public interface OnMessageFound {

--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -321,9 +321,36 @@ public class NotificationService {
             final Account account = conversation.getAccount();
             final boolean doNotify = (!(this.mIsInForeground && this.mOpenConversation == null) || !isScreenOn)
                     && !account.inGracePeriod()
-                    && !this.inMiniGracePeriod(account);
+                    && !this.inMiniGracePeriod(account)
+                    && notifyAgain((Conversation) conversation);
             updateNotification(doNotify, Collections.singletonList(conversation.getUuid()));
         }
+    }
+
+    /**
+     * This method should be used only by a method like {@link #push(Message)} for checking
+     * if the user should be notified for an incoming message while Conversations is not open
+     * or the screen off.
+     * Checks whether a recent receiving of a message inside the given conversation has already led to a notification.
+     * Multiple notifications for multiple incoming messages of one conversation closely following each other
+     * can be avoided by using this method when checking for the need of a new notification.
+     * @param conversation conversation which contains the incoming message maybe triggering a notification.
+     * @return true if the user should be notified or false otherwise
+     */
+    public boolean notifyAgain(Conversation conversation) {
+        // This is true if enough time has passed after the last receiving of a message.
+        boolean timePassed = System.currentTimeMillis() - conversation.getLastPossibleNotificationTime() > Config.MESSAGE_MERGE_WINDOW * 1000;
+
+        boolean notifyAgain = timePassed || conversation.wasResumed();
+        if (!notifyAgain) {
+            Log.d(Config.LOGTAG, conversation.getAccount().getJid().asBareJid()
+                    + ": suppressing notification because time difference to messsage received before is less than "
+                    + Config.MESSAGE_MERGE_WINDOW + "ms and ConversationFragment object"
+                    + "has not been resumed after receiving that message");
+        }
+        conversation.resetResumed();
+        conversation.updateLastPossibleNotificationTime();
+        return notifyAgain;
     }
 
     public void clear() {

--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -1916,6 +1916,9 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
             this.conversation.trim();
         }
 
+        // Set the conversation to "resumed" for receiving notifications again after they were suppressed due to multiple incoming messages.
+		this.conversation.resumed();
+
         setupIme();
 
         final boolean scrolledToBottomAndNoPending = this.scrolledToBottom() && pendingScrollState.peek() == null;


### PR DESCRIPTION
A message arriving quickly after another one will not trigger a sound or vibration notification again.

closes #762