### PR TITLE
Fix backup error for non-unicode numbers

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/ExportBackupService.java
+++ b/src/main/java/eu/siacs/conversations/services/ExportBackupService.java
@@ -192,7 +192,7 @@ public class ExportBackupService extends Service {
             final String value = cursor.getString(i);
             if (value == null) {
                 builder.append("NULL");
-            } else if (value.matches("\\d+")) {
+            } else if (value.matches("[0-9]+")) {
                 builder.append(value);
             } else {
                 DatabaseUtils.appendEscapedSQLString(builder, value);


### PR DESCRIPTION
I've recently reset my phone after using the backup feature of Conversations, but while trying to restore my messages, I got a SQLite error in `logcat` (which I didn't copy unfortunately) saying something like "unexpected integer value for string column" and the backup failed. It referred to a line containing the arabic numbers `١٢٣٤٥٦٧٨٩٠` as a single message, but not surrounded by quotation marks as the other messages.

Fortunately, I was able to decrypt the file with my passwort on the computer, change the corresponding line and encrypt it again so that I was able to import the backup successfully.

Now, I've searched for the reason to this problem and found this line I've changed in the commit: [It seems the regular expression `\\d+` matches arabic numbers too](https://unix.stackexchange.com/a/414230) so that the escaping quotation marks were not added for this message. Changing it to `[0-9]+` should solve the problem.

Note however that I did not compile and test the changes myself.