### PR TITLE
UriHandlerAcitivity: Fix URI forward with no accounts

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/UriHandlerActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/UriHandlerActivity.java
@@ -89,6 +89,7 @@ public class UriHandlerActivity extends AppCompatActivity {
 
         if (accounts.size() == 0) {
             if (xmppUri.isJidValid()) {
+                getIntent().putExtra(StartConversationActivity.EXTRA_INVITE_URI, xmppUri.toString());
                 intent = SignupUtils.getSignUpIntent(this);
                 startActivity(intent);
             } else {


### PR DESCRIPTION
General information

    Version: master
    Device: any
    Android Version: any
    Server name: any

Steps to reproduce

Open an XMPP URI (e.g., xmpp:test@example.com?roster) with no configured accounts.

Expected result

The user can configure an account and gets the 'add contact' dialog for test@example.com afterwards.

Actual result

There is no 'add contact' dialog after account configuration.