### PR TITLE
Add ignore rule for formal signed builds and Update gradle to 5.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,14 @@ proguard/
 
 import-summary.txt
 .navigation/
+
+# Signed package output
+/conversationsFreeCompat/
+/conversationsFreeSystem/
+/conversationsPlaystoreCompat/
+/conversationsPlaystoreSystem/
+/quicksyFreeCompact/
+/quicksyFreeSystem/
+/quicksyPlaystoreCompact/
+/quicksyPlaystoreSystem/
+

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 24 10:50:09 CEST 2019
+#Tue Sep 10 20:07:13 AEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Let git ignore the output directory for signed packages.