### PR TITLE
Correct a small typo in Romanian translation

### DIFF
--- a/src/main/res/values-ro-rRO/strings.xml
+++ b/src/main/res/values-ro-rRO/strings.xml
@@ -413,7 +413,7 @@
   <string name="sending_x_file">Trimit %s</string>
   <string name="offering_x_file">Ofer %s</string>
   <string name="hide_offline">Ascunde deconectat</string>
-  <string name="contact_is_typing">%s tasteaza...</string>
+  <string name="contact_is_typing">%s tastează...</string>
   <string name="contact_has_stopped_typing">%s s-a oprit din scris</string>
   <string name="contacts_are_typing">%s tastează...</string>
   <string name="contacts_have_stopped_typing">%s s-au oprit din scris</string>


### PR DESCRIPTION
I corrected a small, but annoying typo in the Romanian translation.
See https://dexonline.ro/definitie/tasta for the correct conjugation.