### PR TITLE
LMC: find replacedMessages based on bare JID

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -307,8 +307,10 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
 		synchronized (this.messages) {
 			for (int i = this.messages.size() - 1; i >= 0; --i) {
 				final Message message = messages.get(i);
-				if (counterpart.equals(message.getCounterpart())
-						&& ((message.getStatus() == Message.STATUS_RECEIVED) == received)
+				final boolean counterpartMatch = mode == MODE_SINGLE ?
+					counterpart.asBareJid().equals(message.getCounterpart().asBareJid()) :
+					counterpart.equals(message.getCounterpart());
+				if (counterpartMatch && ((message.getStatus() == Message.STATUS_RECEIVED) == received)
 						&& (carbon == message.isCarbon() || received)) {
 					final boolean idMatch = id.equals(message.getRemoteMsgId()) || message.remoteMsgIdMatchInEdit(id);
 					if (idMatch && !message.isFileOrImage() && !message.treatAsDownloadable()) {


### PR DESCRIPTION
When using LMC I'd like Conversations to identify replaced messages based on the bare JID and not on the full JID. Otherwise a corrected message in a one-to-one-chat will be shown as a new message if the user's ressource changes in between. This for example happens in converse.js in case you log off and on in between sending the original and the corrected message.

Furthermore I believe that XEP-0308 states that the bare JID is supposed to be used for matching of a corrected message.