### PR TITLE
Use dark navigation bar in QR scanner activity

### DIFF
--- a/src/main/res/values-v21/themes.xml
+++ b/src/main/res/values-v21/themes.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="ConversationsTheme.Dark" parent="ConversationsTheme.Dark.Base">
-        <item name="android:navigationBarColor">@color/black</item>
-    </style>
-</resources>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -114,9 +114,7 @@
         <item type="reference" name="icon_enable_undecided_device">@drawable/ic_new_releases_black_24dp</item>
     </style>
 
-    <style name="ConversationsTheme.Dark" parent="ConversationsTheme.Dark.Base" />
-
-    <style name="ConversationsTheme.Dark.Base" parent="Theme.AppCompat.NoActionBar">
+    <style name="ConversationsTheme.Dark" parent="Theme.AppCompat.NoActionBar">
         <item name="colorPrimary">@color/green800</item>
         <item name="colorPrimaryDark">@color/green900</item>
         <item name="colorAccent">@color/blue_a100</item>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="ConversationsTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/green600</item>
@@ -119,6 +119,7 @@
         <item name="colorPrimaryDark">@color/green900</item>
         <item name="colorAccent">@color/blue_a100</item>
         <item name="popupOverlayStyle">@style/ThemeOverlay.AppCompat.Dark</item>
+        <item name="android:navigationBarColor" tools:targetApi="21">@color/black</item>
 
         <item name="color_background_primary">@color/grey800</item>
         <item name="color_background_secondary">@color/grey900</item>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -280,6 +280,7 @@
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:navigationBarColor" tools:targetApi="21">@color/black</item>
     </style>
 
     <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">


### PR DESCRIPTION
This is consistent with the black background that is already used in
that activity.

Before:

![before](https://user-images.githubusercontent.com/1718963/65883056-8bb4eb00-e396-11e9-85c4-b05fe4f2e753.jpg)

After:

![after](https://user-images.githubusercontent.com/1718963/65883066-8f487200-e396-11e9-81d7-7792dc79bd28.jpg)

I've also reverted my previous commit that set the dark navigation bar for the rest of activities and made it use `tools:targetApi="21"` that is much cleaner than creating separate themes for API level 21.
