### PR TITLE
Extend the OMEMO auto expiry to 3 months

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -94,7 +94,7 @@ public final class Config {
 
     public static final long MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
 
-    public static final long OMEMO_AUTO_EXPIRY = 14 * MILLISECONDS_IN_DAY;
+    public static final long OMEMO_AUTO_EXPIRY = 90 * MILLISECONDS_IN_DAY;
     public static final boolean REMOVE_BROKEN_DEVICES = false;
     public static final boolean OMEMO_PADDING = false;
     public static final boolean PUT_AUTH_TAG_INTO_KEY = true;


### PR DESCRIPTION
Relevant for https://github.com/siacs/Conversations/issues/3499.

This is the time after which Conversations will kick an OMEMO key from a
users key list.

Note that this is about all keys in the list, not just the one
Conversations is using. So this could be a desktop client that the user
only uses on certain machines that will start losing history after 14
days.