### PR TITLE
added openstreetmap copyright notice to maps

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ShareLocationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ShareLocationActivity.java
@@ -108,8 +108,7 @@ public class ShareLocationActivity extends LocationActivity implements LocationL
 			toggleFixedLocation();
 		});
 
-		TextView openStreetMap_copyright = findViewById(R.id.openstreetmap_credit);
-		openStreetMap_copyright.setMovementMethod(LinkMovementMethod.getInstance());
+		binding.openstreetmapCredit.setMovementMethod(LinkMovementMethod.getInstance());
 	}
 
 	@Override

--- a/src/main/java/eu/siacs/conversations/ui/ShareLocationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ShareLocationActivity.java
@@ -11,7 +11,9 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.Toolbar;
+import android.text.method.LinkMovementMethod;
 import android.view.View;
+import android.widget.TextView;
 
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.util.GeoPoint;
@@ -105,6 +107,9 @@ public class ShareLocationActivity extends LocationActivity implements LocationL
 			}
 			toggleFixedLocation();
 		});
+
+		TextView openStreetMap_copyright = findViewById(R.id.openstreetmap_credit);
+		openStreetMap_copyright.setMovementMethod(LinkMovementMethod.getInstance());
 	}
 
 	@Override

--- a/src/main/res/layout/activity_share_location.xml
+++ b/src/main/res/layout/activity_share_location.xml
@@ -33,7 +33,9 @@
                 android:layout_gravity="bottom|start"
                 android:layout_margin="4dp"
                 android:text="@string/openstreetmap_credit"
-                android:background="#80FFFFFF"
+                android:background="@color/white50"
+                android:paddingLeft="4dp"
+                android:paddingRight="4dp"
                 app:elevation="4dp" />
 
             <android.support.design.widget.FloatingActionButton

--- a/src/main/res/layout/activity_share_location.xml
+++ b/src/main/res/layout/activity_share_location.xml
@@ -26,6 +26,16 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 
+            <TextView
+                android:id="@+id/openstreetmap_credit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|start"
+                android:layout_margin="4dp"
+                android:text="@string/openstreetmap_credit"
+                android:background="#80FFFFFF"
+                app:elevation="4dp" />
+
             <android.support.design.widget.FloatingActionButton
                 android:id="@+id/fab"
                 android:layout_width="wrap_content"

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -9,6 +9,7 @@
 	<color name="white87">#deffffff</color>
 	<color name="white70">#b2ffffff</color>
 	<color name="white12">#1fffffff</color>
+	<color name="white50">#80FFFFFF</color>
 	<color name="grey50">#fffafafa</color>
 	<color name="grey200">#ffeeeeee</color>
 	<color name="grey300">#ffe0e0e0</color>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -882,4 +882,5 @@
     <string name="pref_channel_discovery">Channel discovery method</string>
     <string name="backup">Backup</string>
     <string name="category_about">About</string>
+    <string name="openstreetmap_credit">© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors</string>
 </resources>


### PR DESCRIPTION
closes issue #3588 

![Screenshot_1578160702](https://user-images.githubusercontent.com/8602360/71769700-284dd280-2f1c-11ea-919d-3f2875ea7f07.png)

When the blue and underlined OpenStreetMap is is clicked, the user is presented with this page in their web browser: [https://www.openstreetmap.org/copyright](https://www.openstreetmap.org/copyright)

This follows openstreetmap's guidelines as stated on that page.

Cheers! 