### PR TITLE
show number of participants in a MUC

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -557,7 +557,7 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
             this.binding.noUsersHints.setVisibility(View.VISIBLE);
             this.binding.participantsHints.setVisibility(View.GONE);
         } else {
-            this.binding.participantsHints.setText(getString(R.string.participants, users.size()));
+            this.binding.participantsHints.setText(getResources().getQuantityString(R.plurals.participants, users.size(), users.size()));
             this.binding.participantsHints.setVisibility(View.VISIBLE);
             this.binding.noUsersHints.setVisibility(View.GONE);
         }

--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -555,7 +555,10 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
         if (users.size() == 0) {
             this.binding.noUsersHints.setText(mucOptions.isPrivateAndNonAnonymous() ? R.string.no_users_hint_group_chat : R.string.no_users_hint_channel);
             this.binding.noUsersHints.setVisibility(View.VISIBLE);
+            this.binding.participantsHints.setVisibility(View.GONE);
         } else {
+            this.binding.participantsHints.setText(getString(R.string.participants, users.size()));
+            this.binding.participantsHints.setVisibility(View.VISIBLE);
             this.binding.noUsersHints.setVisibility(View.GONE);
         }
 

--- a/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConferenceDetailsActivity.java
@@ -551,14 +551,12 @@ public class ConferenceDetailsActivity extends XmppActivity implements OnConvers
         this.mUserPreviewAdapter.submitList(MucOptions.sub(users, GridManager.getCurrentColumnCount(binding.users)));
         this.binding.invite.setVisibility(mucOptions.canInvite() ? View.VISIBLE : View.GONE);
         this.binding.showUsers.setVisibility(users.size() > 0 ? View.VISIBLE : View.GONE);
+        this.binding.showUsers.setText(getResources().getQuantityString(R.plurals.view_users, users.size(), users.size()));
         this.binding.usersWrapper.setVisibility(users.size() > 0 || mucOptions.canInvite() ? View.VISIBLE : View.GONE);
         if (users.size() == 0) {
             this.binding.noUsersHints.setText(mucOptions.isPrivateAndNonAnonymous() ? R.string.no_users_hint_group_chat : R.string.no_users_hint_channel);
             this.binding.noUsersHints.setVisibility(View.VISIBLE);
-            this.binding.participantsHints.setVisibility(View.GONE);
         } else {
-            this.binding.participantsHints.setText(getResources().getQuantityString(R.plurals.participants, users.size(), users.size()));
-            this.binding.participantsHints.setVisibility(View.VISIBLE);
             this.binding.noUsersHints.setVisibility(View.GONE);
         }
 

--- a/src/main/res/layout/activity_muc_details.xml
+++ b/src/main/res/layout/activity_muc_details.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -278,7 +279,7 @@
                                 android:minWidth="0dp"
                                 android:paddingLeft="16dp"
                                 android:paddingRight="16dp"
-                                android:text="View n Participants"
+                                tools:text="View n Participants"
                                 android:textColor="?attr/colorAccent" />
                         </LinearLayout>
                     </LinearLayout>

--- a/src/main/res/layout/activity_muc_details.xml
+++ b/src/main/res/layout/activity_muc_details.xml
@@ -241,17 +241,6 @@
                             android:text="@string/no_users_hint_channel"
                             android:textAppearance="@style/TextAppearance.Conversations.Body2"/>
 
-                        <TextView
-                            android:id="@+id/participants_hints"
-                            android:paddingTop="@dimen/card_padding_regular"
-                            android:paddingEnd="@dimen/card_padding_regular"
-                            android:paddingStart="@dimen/card_padding_regular"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/participant"
-                            android:textAppearance="@style/TextAppearance.Conversations.Body2" />
-
-
                         <android.support.v7.widget.RecyclerView
                             android:id="@+id/users"
                             android:layout_width="match_parent"
@@ -289,7 +278,7 @@
                                 android:minWidth="0dp"
                                 android:paddingLeft="16dp"
                                 android:paddingRight="16dp"
-                                android:text="@string/view_users"
+                                android:text="View n Participants"
                                 android:textColor="?attr/colorAccent" />
                         </LinearLayout>
                     </LinearLayout>

--- a/src/main/res/layout/activity_muc_details.xml
+++ b/src/main/res/layout/activity_muc_details.xml
@@ -248,7 +248,7 @@
                             android:paddingStart="@dimen/card_padding_regular"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/participants"
+                            android:text="@string/participant"
                             android:textAppearance="@style/TextAppearance.Conversations.Body2" />
 
 

--- a/src/main/res/layout/activity_muc_details.xml
+++ b/src/main/res/layout/activity_muc_details.xml
@@ -241,6 +241,17 @@
                             android:text="@string/no_users_hint_channel"
                             android:textAppearance="@style/TextAppearance.Conversations.Body2"/>
 
+                        <TextView
+                            android:id="@+id/participants_hints"
+                            android:paddingTop="@dimen/card_padding_regular"
+                            android:paddingEnd="@dimen/card_padding_regular"
+                            android:paddingStart="@dimen/card_padding_regular"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/participants"
+                            android:textAppearance="@style/TextAppearance.Conversations.Body2" />
+
+
                         <android.support.v7.widget.RecyclerView
                             android:id="@+id/users"
                             android:layout_width="match_parent"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -753,7 +753,6 @@
     <string name="pref_more_notification_settings_summary">Importance, Sound, Vibrate</string>
     <string name="video_compression_channel_name">Video compression</string>
     <string name="view_media">View media</string>
-    <string name="view_users">View participants</string>
     <string name="group_chat_members">Participants</string>
     <string name="media_browser">Media browser</string>
     <string name="security_violation_not_attaching_file">File omitted due to security violation.</string>
@@ -882,8 +881,8 @@
     <string name="pref_channel_discovery">Channel discovery method</string>
     <string name="backup">Backup</string>
     <string name="category_about">About</string>
-    <plurals name="participants">
-        <item quantity="one">%1$d Participant</item>
-        <item quantity="other">%1$d Participants</item>
+    <plurals name="view_users">
+        <item quantity="one">View %1$d Participant</item>
+        <item quantity="other">View %1$d Participants</item>
     </plurals>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -882,4 +882,5 @@
     <string name="pref_channel_discovery">Channel discovery method</string>
     <string name="backup">Backup</string>
     <string name="category_about">About</string>
+    <string name="participants">%1$d Participant(s)</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -882,5 +882,8 @@
     <string name="pref_channel_discovery">Channel discovery method</string>
     <string name="backup">Backup</string>
     <string name="category_about">About</string>
-    <string name="participants">%1$d Participant(s)</string>
+    <plurals name="participants">
+        <item quantity="one">%1$d Participant</item>
+        <item quantity="other">%1$d Participants</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
closes  #3447

![Screenshot_1578163830](https://user-images.githubusercontent.com/8602360/71770364-9649c800-2f23-11ea-9403-84abe01f7513.png)

I chose the string `participant(s)`, however I am unsure how this will affect the translatability of this string. If you have a better recommendation for this string, please let me know and I will change it.