### PR TITLE
[WIP] changed view conversation to jump to location

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
@@ -97,6 +97,7 @@ public class ConversationsActivity extends XmppActivity implements OnConversatio
     public static final String EXTRA_NICK = "nick";
     public static final String EXTRA_IS_PRIVATE_MESSAGE = "pm";
     public static final String EXTRA_DO_NOT_APPEND = "do_not_append";
+    public static final String EXTRA_UUID = "uuid";
 
     private static List<String> VIEW_AND_SHARE_ACTIONS = Arrays.asList(
             ACTION_VIEW_CONVERSATION,

--- a/src/main/java/eu/siacs/conversations/ui/SearchActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SearchActivity.java
@@ -153,7 +153,7 @@ public class SearchActivity extends XmppActivity implements TextWatcher, OnSearc
 		if (message != null) {
 			switch (item.getItemId()) {
 				case R.id.open_conversation:
-					switchToConversation(wrap(message.getConversation()));
+					switchToConversationAndGo(wrap(message.getConversation()), message.getUuid());
 					break;
 				case R.id.share_with:
 					ShareUtil.share(this, message);

--- a/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/XmppActivity.java
@@ -457,26 +457,31 @@ public abstract class XmppActivity extends ActionBarActivity {
 	}
 
 	public void switchToConversationAndQuote(Conversation conversation, String text) {
-		switchToConversation(conversation, text, true, null, false, false);
+		switchToConversation(conversation, text, true, null, false, false, null);
 	}
 
 	public void switchToConversation(Conversation conversation, String text) {
-		switchToConversation(conversation, text, false, null, false, false);
+		switchToConversation(conversation, text, false, null, false, false, null);
 	}
 
 	public void switchToConversationDoNotAppend(Conversation conversation, String text) {
-		switchToConversation(conversation, text, false, null, false, true);
+		switchToConversation(conversation, text, false, null, false, true, null);
 	}
 
 	public void highlightInMuc(Conversation conversation, String nick) {
-		switchToConversation(conversation, null, false, nick, false, false);
+		switchToConversation(conversation, null, false, nick, false, false, null);
 	}
 
 	public void privateMsgInMuc(Conversation conversation, String nick) {
-		switchToConversation(conversation, null, false, nick, true, false);
+		switchToConversation(conversation, null, false, nick, true, false, null);
 	}
 
-	private void switchToConversation(Conversation conversation, String text, boolean asQuote, String nick, boolean pm, boolean doNotAppend) {
+	public void switchToConversationAndGo(Conversation conversation, String uuid) {
+		switchToConversation(conversation, null, false, null, false, true, uuid);
+	}
+
+
+	private void switchToConversation(Conversation conversation, String text, boolean asQuote, String nick, boolean pm, boolean doNotAppend, String uuid) {
 		Intent intent = new Intent(this, ConversationsActivity.class);
 		intent.setAction(ConversationsActivity.ACTION_VIEW_CONVERSATION);
 		intent.putExtra(ConversationsActivity.EXTRA_CONVERSATION, conversation.getUuid());
@@ -492,6 +497,9 @@ public abstract class XmppActivity extends ActionBarActivity {
 		}
 		if (doNotAppend) {
 			intent.putExtra(ConversationsActivity.EXTRA_DO_NOT_APPEND, true);
+		}
+		if (uuid != null) {
+			intent.putExtra(ConversationsActivity.EXTRA_UUID, uuid);
 		}
 		intent.setFlags(intent.getFlags() | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 		startActivity(intent);


### PR DESCRIPTION
My attempt at #3101 

This patch works if the message the user selects from the search activity is one of the  messages that are loaded when user first taps the conversation from homescreen.

I need help with loading older messages `while getIndexOf(uuid, this.messageList) < 0` in `processExtras(Bundle extras)`. I have tried calling `moveToMsg(0)` with the hopes that the `onScroll()` function that loads more messages when user scrolls to top gets called, Unfortunately, this didnt work....
I cannot think of another fix please help.

I also did some refactoring (moving things to functions) so that I could re-use as much code as possible.