### PR TITLE
simplify osm attribution

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/LocationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/LocationActivity.java
@@ -27,6 +27,7 @@ import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.Overlay;
 
 import java.io.IOException;
@@ -71,7 +72,7 @@ public abstract class LocationActivity extends ActionBarActivity implements Loca
 	protected void updateLocationMarkers() {
 		clearMarkers();
 	}
-	
+
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -130,6 +131,7 @@ public abstract class LocationActivity extends ActionBarActivity implements Loca
 
 	protected void setupMapView(MapView mapView, final GeoPoint pos) {
 		map = mapView;
+		map.getOverlays().add(new CopyrightOverlay(this));
 		map.setTileSource(TileSourceFactory.MAPNIK);
 		map.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.NEVER);
 		map.setMultiTouchControls(true);

--- a/src/main/java/eu/siacs/conversations/ui/ShareLocationActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ShareLocationActivity.java
@@ -11,9 +11,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.Toolbar;
-import android.text.method.LinkMovementMethod;
 import android.view.View;
-import android.widget.TextView;
 
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.util.GeoPoint;
@@ -107,8 +105,6 @@ public class ShareLocationActivity extends LocationActivity implements LocationL
 			}
 			toggleFixedLocation();
 		});
-
-		binding.openstreetmapCredit.setMovementMethod(LinkMovementMethod.getInstance());
 	}
 
 	@Override

--- a/src/main/res/layout/activity_share_location.xml
+++ b/src/main/res/layout/activity_share_location.xml
@@ -26,18 +26,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 
-            <TextView
-                android:id="@+id/openstreetmap_credit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="bottom|start"
-                android:layout_margin="4dp"
-                android:text="@string/openstreetmap_credit"
-                android:background="@color/white50"
-                android:paddingLeft="4dp"
-                android:paddingRight="4dp"
-                app:elevation="4dp" />
-
             <android.support.design.widget.FloatingActionButton
                 android:id="@+id/fab"
                 android:layout_width="wrap_content"

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -9,7 +9,6 @@
 	<color name="white87">#deffffff</color>
 	<color name="white70">#b2ffffff</color>
 	<color name="white12">#1fffffff</color>
-	<color name="white50">#80FFFFFF</color>
 	<color name="grey50">#fffafafa</color>
 	<color name="grey200">#ffeeeeee</color>
 	<color name="grey300">#ffe0e0e0</color>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -886,5 +886,4 @@
         <item quantity="one">View %1$d Participant</item>
         <item quantity="other">View %1$d Participants</item>
     </plurals>
-    <string name="openstreetmap_credit">© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors</string>
 </resources>


### PR DESCRIPTION
I believe the current implementation of OSM attribution is unnecessarily complex.

I propose to just use osmdroid's CopyrightOverlay because it's basically one line of code to be added and it gets the attribution text from the mapsource which is obviously the more flexible approach (e.g. if you want to support multiple map sources).