### PR TITLE
Update README.md to mention XEP-0198 is required for push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you don’t want this simply pick a server which does not offer Push Notifica
 
 You can find a detailed description of how your server, the app server and FCM are interacting with each other in the [README](https://github.com/iNPUTmice/p2/blob/master/README.md) of the Conversations App Server.
 
- ¹ Your server only needs to support the server side of [XEP-0357: Push Notifications](http://xmpp.org/extensions/xep-0357.html). If you use the Play Store version you do **not** need to run your own app server. The server modules are called *mod_cloud_notify* on Prosody and *mod_push* on ejabberd.
+ ¹ If you use the Play Store version you do **not** need to run your own app server. Your server only needs to support the server side of [XEP-0357: Push Notifications](http://xmpp.org/extensions/xep-0357.html) and [XEP-0198: Stream Management](https://xmpp.org/extensions/xep-0198.html). The prosody server modules are called *mod_cloud_notify* and *mod_smacks*. The ejabberd server modules are called *mod_push* and *mod_stream_mgmt*.
 
 
 #### But why do I need a permanent notification if I use Google Push?


### PR DESCRIPTION
I recently setup my own Prosody server, and tried to get Conversations with Push support working with it.

Unfortunately I wasted a bunch of time because even though I added the `cloud_notify` module to Prosody, and the module loaded without error, Conversations would show "XEP-0357: Push - Unavailable". This lead me to spend a bunch of time debugging the the `cloud_notify` module and XEP-0357 discovery, etc, etc..

It turns out the problem was that I didn't have **XEP-0198: Stream Management** support on my server, once I loaded that module everything worked as expected. Also, it makes perfect sense that stream management is required for Push to work efficiently.

This Pull Request just adds some information to the README.me file that mentions XEP-0198 support is required on the server. Maybe it'll save some other people time in the future :)

Thanks!

--jbit