### PR TITLE
get external-storage permission on attach location

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -1308,7 +1308,7 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
             if (!hasPermissions(attachmentChoice, Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA)) {
                 return;
             }
-        } else if (attachmentChoice != ATTACHMENT_CHOICE_LOCATION) {
+        } else {
             if (!hasPermissions(attachmentChoice, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                 return;
             }


### PR DESCRIPTION
Fix a problem of not previewing the map due to the lack of external-storage permission