### PR TITLE
[~] scramble JID in logs & close FileInputStream

### DIFF
--- a/src/main/java/eu/siacs/conversations/crypto/PgpEngine.java
+++ b/src/main/java/eu/siacs/conversations/crypto/PgpEngine.java
@@ -41,9 +41,9 @@ public class PgpEngine {
 	private static void logError(Account account, OpenPgpError error) {
 		if (error != null) {
 			error.describeContents();
-			Log.d(Config.LOGTAG, account.getJid().asBareJid().toString() + ": OpenKeychain error '" + error.getMessage() + "' code=" + error.getErrorId()+" class="+error.getClass().getName());
+			Log.d(Config.LOGTAG, account.getLogJid() + ": OpenKeychain error '" + error.getMessage() + "' code=" + error.getErrorId()+" class="+error.getClass().getName());
 		} else {
-			Log.d(Config.LOGTAG, account.getJid().asBareJid().toString() + ": OpenKeychain error with no message");
+			Log.d(Config.LOGTAG, account.getLogJid() + ": OpenKeychain error with no message");
 		}
 	}
 
@@ -218,7 +218,7 @@ public class PgpEngine {
 		params.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, account.getPgpId());
 		InputStream is = new ByteArrayInputStream(status.getBytes());
 		final OutputStream os = new ByteArrayOutputStream();
-		Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": signing status message \"" + status + "\"");
+		Log.d(Config.LOGTAG, account.getLogJid() + ": signing status message \"" + status + "\"");
 		api.executeApiAsync(params, is, os, result -> {
 			switch (result.getIntExtra(OpenPgpApi.RESULT_CODE, 0)) {
 				case OpenPgpApi.RESULT_CODE_SUCCESS:

--- a/src/main/java/eu/siacs/conversations/crypto/axolotl/AxolotlService.java
+++ b/src/main/java/eu/siacs/conversations/crypto/axolotl/AxolotlService.java
@@ -117,7 +117,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                 && account.getXmppConnection().getFeatures().pep()) {
             publishBundlesIfNeeded(true, false);
         } else {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": skipping OMEMO initialization");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": skipping OMEMO initialization");
         }
     }
 
@@ -263,12 +263,12 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
     }
 
     public void destroy() {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": destroying old axolotl service. no longer in use");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": destroying old axolotl service. no longer in use");
         mXmppConnectionService.databaseBackend.wipeAxolotlDb(account);
     }
 
     public AxolotlService makeNew() {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": make new axolotl service");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": make new axolotl service");
         return new AxolotlService(this.account, this.mXmppConnectionService);
     }
 
@@ -289,7 +289,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
         final boolean me = jid.asBareJid().equals(account.getJid().asBareJid());
         if (me) {
             if (hash != 0 && hash == this.lastDeviceListNotificationHash) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": ignoring duplicate own device id list");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": ignoring duplicate own device id list");
                 return;
             }
             this.lastDeviceListNotificationHash = hash;
@@ -384,7 +384,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                     //TODO consider calling registerDevices only after item-not-found to account for broken PEPs
                     Element item = mXmppConnectionService.getIqParser().getItem(packet);
                     Set<Integer> deviceIds = mXmppConnectionService.getIqParser().deviceIds(item);
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": retrieved own device list: " + deviceIds);
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": retrieved own device list: " + deviceIds);
                     registerDevices(account.getJid().asBareJid(), deviceIds);
                 }
             }
@@ -402,9 +402,9 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                     if (lastMessageDiff > Config.OMEMO_AUTO_EXPIRY) {
                         devices.add(session.getRemoteAddress().getDeviceId());
                         session.setTrust(session.getTrust().toInactive());
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": added own device " + session.getFingerprint() + " to list of expired devices. Last message received " + hours + " hours ago");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": added own device " + session.getFingerprint() + " to list of expired devices. Last message received " + hours + " hours ago");
                     } else {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": own device " + session.getFingerprint() + " was active " + hours + " hours ago");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": own device " + session.getFingerprint() + " was active " + hours + " hours ago");
                     }
                 } //TODO print last activation diff
             }
@@ -444,7 +444,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                 final Element error = packet.getType() == IqPacket.TYPE.ERROR ? packet.findChild("error") : null;
                 final boolean preConditionNotMet = PublishOptions.preconditionNotMet(packet);
                 if (firstAttempt && preConditionNotMet) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": precondition wasn't met for device list. pushing node configuration");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": precondition wasn't met for device list. pushing node configuration");
                     mXmppConnectionService.pushNodeConfiguration(account, AxolotlService.PEP_DEVICE_LIST, publishOptions, new XmppConnectionService.OnConfigurationPushed() {
                         @Override
                         public void onPushSucceeded() {
@@ -458,13 +458,13 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                     });
                 } else {
                     if (AxolotlService.this.changeAccessMode.compareAndSet(true, false)) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": done changing access mode");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": done changing access mode");
                         account.setOption(Account.OPTION_REQUIRES_ACCESS_MODE_CHANGE, false);
                         mXmppConnectionService.databaseBackend.updateAccount(account);
                     }
                     if (packet.getType() == IqPacket.TYPE.ERROR) {
                         if (preConditionNotMet) {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": device list pre condition still not met on second attempt");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": device list pre condition still not met on second attempt");
                         } else if (error != null) {
                             pepBroken = true;
                             Log.d(Config.LOGTAG, getLogprefix(account) + "Error received while publishing own device id" + packet.findChild("error"));
@@ -524,12 +524,12 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
             this.changeAccessMode.set(account.isOptionSet(Account.OPTION_REQUIRES_ACCESS_MODE_CHANGE));
         } else {
             if (account.setOption(Account.OPTION_REQUIRES_ACCESS_MODE_CHANGE, true)) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": server doesn’t support publish-options. setting for later access mode change");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": server doesn’t support publish-options. setting for later access mode change");
                 mXmppConnectionService.databaseBackend.updateAccount(account);
             }
         }
         if (this.changeAccessMode.get()) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": server gained publish-options capabilities. changing access model");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": server gained publish-options capabilities. changing access model");
         }
         IqPacket packet = mXmppConnectionService.getIqGenerator().retrieveBundlesForDevice(account.getJid().asBareJid(), getOwnDeviceId());
         mXmppConnectionService.sendIqPacket(account, packet, new OnIqPacketReceived() {
@@ -660,7 +660,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
             public void onIqPacketReceived(final Account account, IqPacket packet) {
                 final boolean preconditionNotMet = PublishOptions.preconditionNotMet(packet);
                 if (firstAttempt && preconditionNotMet) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": precondition wasn't met for bundle. pushing node configuration");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": precondition wasn't met for bundle. pushing node configuration");
                     final String node = AxolotlService.PEP_BUNDLES + ":" + getOwnDeviceId();
                     mXmppConnectionService.pushNodeConfiguration(account, node, publishOptions, new XmppConnectionService.OnConfigurationPushed() {
                         @Override
@@ -802,7 +802,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                 int id = entry.getKey();
                 if (entry.getValue() == FetchStatus.ERROR && PREVIOUSLY_REMOVED_FROM_ANNOUNCEMENT.add(id) && ownDeviceIds.remove(id)) {
                     publish = true;
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": error fetching own device with id " + id + ". removing from announcement");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": error fetching own device with id " + id + ". removing from announcement");
                 }
             }
             if (publish) {
@@ -827,7 +827,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                 if (callback != null) {
                     callbacks.add(callback);
                 }
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": fetching device ids for " + jid + " already running. adding callback");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": fetching device ids for " + jid + " already running. adding callback");
                 packet = null;
             } else {
                 callbacks = new ArrayList<>();
@@ -835,7 +835,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                     callbacks.add(callback);
                 }
                 this.fetchDeviceIdsMap.put(jid, callbacks);
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": fetching device ids for " + jid);
+                Log.d(Config.LOGTAG, account.getLogJid() + ": fetching device ids for " + jid);
                 packet = mXmppConnectionService.getIqGenerator().retrieveDeviceIds(jid);
             }
         }
@@ -992,7 +992,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
     private void removeFromDeviceAnnouncement(Integer id) {
         HashSet<Integer> temp = new HashSet<>(getOwnDeviceIds());
         if (temp.remove(id)) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + " remove own device id " + id + " from announcement. devices left:" + temp);
+            Log.d(Config.LOGTAG, account.getLogJid() + " remove own device id " + id + " from announcement. devices left:" + temp);
             publishOwnDeviceId(temp);
         }
     }
@@ -1057,7 +1057,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
                 iterator.remove();
             }
         }
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": createSessionsIfNeeded() - jids with empty device list: " + jidsWithEmptyDeviceList);
+        Log.d(Config.LOGTAG, account.getLogJid() + ": createSessionsIfNeeded() - jids with empty device list: " + jidsWithEmptyDeviceList);
         if (jidsWithEmptyDeviceList.size() > 0) {
             fetchDeviceIds(jidsWithEmptyDeviceList, () -> createSessionsIfNeededActual(conversation));
             return true;
@@ -1290,7 +1290,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
 
     private void notifyRequiresHealing(final SignalProtocolAddress signalProtocolAddress) {
         if (healingAttempts.add(signalProtocolAddress)) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": attempt to heal " + signalProtocolAddress);
+            Log.d(Config.LOGTAG, account.getLogJid() + ": attempt to heal " + signalProtocolAddress);
             buildSessionFromPEP(signalProtocolAddress, new OnSessionBuildFromPep() {
                 @Override
                 public void onSessionBuildSuccessful() {
@@ -1300,11 +1300,11 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
 
                 @Override
                 public void onSessionBuildFailed() {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": unable to build new session from pep after detecting broken session");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": unable to build new session from pep after detecting broken session");
                 }
             });
         } else {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": do not attempt to heal " + signalProtocolAddress + " again");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": do not attempt to heal " + signalProtocolAddress + " again");
         }
     }
 
@@ -1315,7 +1315,7 @@ public class AxolotlService implements OnAdvancedStreamFeaturesLoaded {
             if (axolotlStore.flushPreKeys()) {
                 publishBundlesIfNeeded(false, false);
             } else {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": nothing to flush. Not republishing key");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": nothing to flush. Not republishing key");
             }
             if (trustedOrPreviouslyResponded(session)) {
                 completeSession(session);

--- a/src/main/java/eu/siacs/conversations/entities/Account.java
+++ b/src/main/java/eu/siacs/conversations/entities/Account.java
@@ -16,7 +16,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import eu.siacs.conversations.Config;
@@ -324,6 +323,20 @@ public class Account extends AbstractEntity implements AvatarService.Avatarable 
 
     public Jid getJid() {
         return jid;
+    }
+
+    public String getLogJid() {
+        StringBuilder logJidBuilder = new StringBuilder();
+        logJidBuilder.append(jid.getLocal().charAt(0));
+        for (int i = 1; i < jid.getLocal().length(); i++) {
+            logJidBuilder.append("*");
+        }
+        logJidBuilder.append("@");
+        logJidBuilder.append(jid.getDomain().charAt(0));
+        for (int i = 1; i < jid.getDomain().length(); i++) {
+            logJidBuilder.append("*");
+        }
+        return logJidBuilder.toString();
     }
 
     public JSONObject getKeys() {

--- a/src/main/java/eu/siacs/conversations/http/HttpUploadConnection.java
+++ b/src/main/java/eu/siacs/conversations/http/HttpUploadConnection.java
@@ -121,7 +121,7 @@ public class HttpUploadConnection implements Transferable {
 			try {
 				md5 = Checksum.md5(AbstractConnectionManager.upgrade(file, new FileInputStream(file)));
 			} catch (Exception e) {
-				Log.d(Config.LOGTAG, account.getJid().asBareJid()+": unable to calculate md5()", e);
+				Log.d(Config.LOGTAG, account.getLogJid()+": unable to calculate md5()", e);
 				fail(e.getMessage());
 				return;
 			}

--- a/src/main/java/eu/siacs/conversations/http/SlotRequester.java
+++ b/src/main/java/eu/siacs/conversations/http/SlotRequester.java
@@ -88,7 +88,7 @@ public class SlotRequester {
 					}
 				}
 			}
-			Log.d(Config.LOGTAG, account.getJid().toString() + ": invalid response to slot request " + packet);
+			Log.d(Config.LOGTAG, account.getLogJid() + ": invalid response to slot request " + packet);
 			callback.failure(IqParser.extractErrorMessage(packet));
 		});
 
@@ -127,7 +127,7 @@ public class SlotRequester {
 					}
 				}
 			}
-			Log.d(Config.LOGTAG, account.getJid().toString() + ": invalid response to slot request " + packet);
+			Log.d(Config.LOGTAG, account.getLogJid() + ": invalid response to slot request " + packet);
 			callback.failure(IqParser.extractErrorMessage(packet));
 		});
 

--- a/src/main/java/eu/siacs/conversations/parser/IqParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/IqParser.java
@@ -76,7 +76,7 @@ public class IqParser extends AbstractParser implements OnIqPacketReceived {
                 }
                 boolean both = contact.getOption(Contact.Options.TO) && contact.getOption(Contact.Options.FROM);
                 if ((both != bothPre) && both) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": gained mutual presence subscription with " + contact.getJid());
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": gained mutual presence subscription with " + contact.getJid());
                     AxolotlService axolotlService = account.getAxolotlService();
                     if (axolotlService != null) {
                         axolotlService.clearErrorsInFetchStatusMap(contact.getJid());

--- a/src/main/java/eu/siacs/conversations/parser/MessageParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/MessageParser.java
@@ -230,9 +230,9 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
                 final Element storage = i == null ? null : i.findChild("storage", Namespace.BOOKMARKS);
                 Map<Jid, Bookmark> bookmarks = Bookmark.parseFromStorage(storage, account);
                 mXmppConnectionService.processBookmarksInitial(account, bookmarks, true);
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": processing bookmark PEP event");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": processing bookmark PEP event");
             } else {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": ignoring bookmark PEP event because bookmark conversion was not detected");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": ignoring bookmark PEP event because bookmark conversion was not detected");
             }
         } else if (Namespace.BOOKMARKS2.equals(node) && account.getJid().asBareJid().equals(from)) {
             final Element item = items.findChild("item");
@@ -348,7 +348,7 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
             serverMsgId = result.getAttribute("id");
             query.incrementMessageCount();
         } else if (query != null) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received mam result from invalid sender");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received mam result from invalid sender");
             return;
         } else if (original.fromServer(account)) {
             Pair<MessagePacket, Long> f;
@@ -421,7 +421,7 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
             if (isTypeGroupChat) {
                 Log.d(Config.LOGTAG,account.getJid().asBareJid()+": ignoring invite to "+invite.jid+" because type=groupchat");
             } else if (invite.direct && (mucUserElement != null || invite.inviter == null || mXmppConnectionService.isMuc(account, invite.inviter))) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid()+": ignoring direct invite to "+invite.jid+" because it was received in MUC");
+                Log.d(Config.LOGTAG, account.getLogJid()+": ignoring direct invite to "+invite.jid+" because it was received in MUC");
             } else {
                 invite.execute(account);
                 return;
@@ -510,7 +510,7 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
                     for (Jid fallback : fallbacksBySourceId) {
                         trial = parseAxolotlChat(axolotlEncrypted, fallback, conversation, status, checkedForDuplicates && fallbacksBySourceId.size() == 1, query != null);
                         if (trial != null) {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": decoded muc message using fallback");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": decoded muc message using fallback");
                             origin = fallback;
                             break;
                         }
@@ -526,7 +526,7 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
                         if (previouslySent != null && previouslySent.getServerMsgId() == null && serverMsgId != null) {
                             previouslySent.setServerMsgId(serverMsgId);
                             mXmppConnectionService.databaseBackend.updateMessage(previouslySent, false);
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": encountered previously sent OMEMO message without serverId. updating...");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": encountered previously sent OMEMO message without serverId. updating...");
                         }
                     }
                     return;
@@ -633,14 +633,14 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
                         mXmppConnectionService.getNotificationService().updateNotification();
                         return;
                     } else {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received message correction but verification didn't check out");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": received message correction but verification didn't check out");
                     }
                 }
             }
 
             long deletionDate = mXmppConnectionService.getAutomaticMessageDeletionDate();
             if (deletionDate != 0 && message.getTimeSent() < deletionDate) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": skipping message from " + message.getCounterpart().toString() + " because it was sent prior to our deletion date");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": skipping message from " + message.getCounterpart().toString() + " because it was sent prior to our deletion date");
                 return;
             }
 
@@ -743,9 +743,9 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
                 try {
                     final XmppAxolotlMessage xmppAxolotlMessage = XmppAxolotlMessage.fromElement(axolotlEncrypted, origin.asBareJid());
                     account.getAxolotlService().processReceivingKeyTransportMessage(xmppAxolotlMessage, query != null);
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": omemo key transport message received from " + origin);
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": omemo key transport message received from " + origin);
                 } catch (Exception e) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": invalid omemo key transport message received " + e.getMessage());
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": invalid omemo key transport message received " + e.getMessage());
                     return;
                 }
             }
@@ -781,7 +781,7 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
                         }
                     } else if ("item".equals(child.getName())) {
                         MucOptions.User user = AbstractParser.parseItem(conversation, child);
-                        Log.d(Config.LOGTAG, account.getJid() + ": changing affiliation for "
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": changing affiliation for "
                                 + user.getRealJid() + " to " + user.getAffiliation() + " in "
                                 + conversation.getJid().asBareJid());
                         if (!user.realJidMatchesAccount()) {
@@ -794,7 +794,7 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
                                 Jid jid = user.getRealJid();
                                 List<Jid> cryptoTargets = conversation.getAcceptedCryptoTargets();
                                 if (cryptoTargets.remove(user.getRealJid())) {
-                                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": removed " + jid + " from crypto targets of " + conversation.getName());
+                                    Log.d(Config.LOGTAG, account.getLogJid() + ": removed " + jid + " from crypto targets of " + conversation.getName());
                                     conversation.setAcceptedCryptoTargets(cryptoTargets);
                                     mXmppConnectionService.updateConversation(conversation);
                                 }
@@ -923,7 +923,7 @@ public class MessageParser extends AbstractParser implements OnMessagePacketRece
 
     private void activateGracePeriod(Account account) {
         long duration = mXmppConnectionService.getLongPreference("grace_period_length", R.integer.grace_period) * 1000;
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": activating grace period till " + TIME_FORMAT.format(new Date(System.currentTimeMillis() + duration)));
+        Log.d(Config.LOGTAG, account.getLogJid() + ": activating grace period till " + TIME_FORMAT.format(new Date(System.currentTimeMillis() + duration)));
         account.activateGracePeriod(duration);
     }
 

--- a/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/DatabaseBackend.java
@@ -371,7 +371,7 @@ public class DatabaseBackend extends SQLiteOpenHelper {
                                     + SQLiteAxolotlStore.FINGERPRINT + " = ? ",
                             selectionArgs);
                 } else {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": could not load own identity key pair");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": could not load own identity key pair");
                 }
             }
         }
@@ -1015,7 +1015,7 @@ public class DatabaseBackend extends SQLiteOpenHelper {
         account.setRosterVersion(roster.getVersion());
         updateAccount(account);
         long duration = SystemClock.elapsedRealtime() - start;
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": persisted roster in " + duration + "ms");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": persisted roster in " + duration + "ms");
     }
 
     public void deleteMessagesInConversation(Conversation conversation) {

--- a/src/main/java/eu/siacs/conversations/services/AvatarService.java
+++ b/src/main/java/eu/siacs/conversations/services/AvatarService.java
@@ -673,7 +673,7 @@ public class AvatarService implements OnAdvancedStreamFeaturesLoaded {
 	public void onAdvancedStreamFeaturesAvailable(Account account) {
 		XmppConnection.Features features = account.getXmppConnection().getFeatures();
 		if (features.pep() && !features.pepPersistent()) {
-			Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": has pep but is not persistent");
+			Log.d(Config.LOGTAG, account.getLogJid() + ": has pep but is not persistent");
 			if (account.getAvatar() != null) {
 				mXmppConnectionService.republishAvatarIfNeeded(account);
 			}

--- a/src/main/java/eu/siacs/conversations/services/MessageArchiveService.java
+++ b/src/main/java/eu/siacs/conversations/services/MessageArchiveService.java
@@ -226,7 +226,7 @@ public class MessageArchiveService implements OnAdvancedStreamFeaturesLoaded {
 	private void execute(final Query query) {
 		final Account account = query.getAccount();
 		if (account.getStatus() == Account.State.ONLINE) {
-			Log.d(Config.LOGTAG, account.getJid().asBareJid().toString() + ": running mam query " + query.toString());
+			Log.d(Config.LOGTAG, account.getLogJid() + ": running mam query " + query.toString());
 			IqPacket packet = this.mXmppConnectionService.getIqGenerator().queryMessageArchiveManagement(query);
 			this.mXmppConnectionService.sendIqPacket(account, packet, (a, p) -> {
 				Element fin = p.findChild("fin", query.version.namespace);

--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -269,7 +269,7 @@ public class NotificationService {
                 it.remove();
             }
         }
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": backlog message count=" + count);
+        Log.d(Config.LOGTAG, account.getLogJid() + ": backlog message count=" + count);
         return count;
     }
 

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -190,7 +190,7 @@ public class XmppConnectionService extends Service {
             Element error = packet.findChild("error");
             String text = error != null ? error.findChildContent("text") : null;
             if (text != null) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received iq error - " + text);
+                Log.d(Config.LOGTAG, account.getLogJid() + ": received iq error - " + text);
             }
         }
     };
@@ -302,7 +302,7 @@ public class XmppConnectionService extends Service {
 
             if (loggedInSuccessfully) {
                 if (!TextUtils.isEmpty(account.getDisplayName())) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": display name wasn't empty on first log in. publishing");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": display name wasn't empty on first log in. publishing");
                     publishDisplayName(account);
                 }
             }
@@ -359,7 +359,7 @@ public class XmppConnectionService extends Service {
             if (account.getStatus() == Account.State.ONLINE) {
                 synchronized (mLowPingTimeoutMode) {
                     if (mLowPingTimeoutMode.remove(account.getJid().asBareJid())) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": leaving low ping timeout mode");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": leaving low ping timeout mode");
                     }
                 }
                 if (account.setShowErrorNotification(true)) {
@@ -368,10 +368,10 @@ public class XmppConnectionService extends Service {
                 mMessageArchiveService.executePendingQueries(account);
                 if (connection != null && connection.getFeatures().csi()) {
                     if (checkListeners()) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + " sending csi//inactive");
+                        Log.d(Config.LOGTAG, account.getLogJid() + " sending csi//inactive");
                         connection.sendInactive();
                     } else {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + " sending csi//active");
+                        Log.d(Config.LOGTAG, account.getLogJid() + " sending csi//active");
                         connection.sendActive();
                     }
                 }
@@ -412,7 +412,7 @@ public class XmppConnectionService extends Service {
             } else if (account.getStatus() == Account.State.OFFLINE || account.getStatus() == Account.State.DISABLED) {
                 resetSendingToWaiting(account);
                 if (account.isEnabled() && isInLowPingTimeoutMode(account)) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": went into offline state during low ping mode. reconnecting now");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": went into offline state during low ping mode. reconnecting now");
                     reconnectAccount(account, true, false);
                 } else {
                     int timeToReconnect = mRandom.nextInt(10) + 2;
@@ -427,11 +427,11 @@ public class XmppConnectionService extends Service {
                     final int next = connection.getTimeToNextAttempt();
                     final boolean lowPingTimeoutMode = isInLowPingTimeoutMode(account);
                     if (next <= 0) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": error connecting account. reconnecting now. lowPingTimeout=" + lowPingTimeoutMode);
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": error connecting account. reconnecting now. lowPingTimeout=" + lowPingTimeoutMode);
                         reconnectAccount(account, true, false);
                     } else {
                         final int attempt = connection.getAttempt() + 1;
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": error connecting account. try again in " + next + "s for the " + attempt + " time. lowPingTimeout=" + lowPingTimeoutMode);
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": error connecting account. try again in " + next + "s for the " + attempt + " time. lowPingTimeout=" + lowPingTimeoutMode);
                         scheduleWakeUpCall(next, account.getUuid().hashCode());
                     }
                 }
@@ -754,7 +754,7 @@ public class XmppConnectionService extends Service {
                 for (Account account : pingCandidates) {
                     final boolean lowTimeout = isInLowPingTimeoutMode(account);
                     account.getXmppConnection().sendPing();
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + " send ping (action=" + action + ",lowTimeout=" + Boolean.toString(lowTimeout) + ")");
+                    Log.d(Config.LOGTAG, account.getLogJid() + " send ping (action=" + action + ",lowTimeout=" + Boolean.toString(lowTimeout) + ")");
                     scheduleWakeUpCall(lowTimeout ? Config.LOW_PING_TIMEOUT : Config.PING_TIMEOUT, account.getUuid().hashCode());
                 }
             }
@@ -791,7 +791,7 @@ public class XmppConnectionService extends Service {
                         long pingTimeoutIn = (lastSent + pingTimeout) - SystemClock.elapsedRealtime();
                         if (lastSent > lastReceived) {
                             if (pingTimeoutIn < 0) {
-                                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": ping timeout");
+                                Log.d(Config.LOGTAG, account.getLogJid() + ": ping timeout");
                                 this.reconnectAccount(account, true, interactive);
                             } else {
                                 int secs = (int) (pingTimeoutIn / 1000);
@@ -802,14 +802,14 @@ public class XmppConnectionService extends Service {
                             if (isAccountPushed) {
                                 pingNow = true;
                                 if (mLowPingTimeoutMode.add(account.getJid().asBareJid())) {
-                                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": entering low ping timeout mode");
+                                    Log.d(Config.LOGTAG, account.getLogJid() + ": entering low ping timeout mode");
                                 }
                             } else if (msToNextPing <= 0) {
                                 pingNow = true;
                             } else {
                                 this.scheduleWakeUpCall((int) (msToNextPing / 1000), account.getUuid().hashCode());
                                 if (mLowPingTimeoutMode.remove(account.getJid().asBareJid())) {
-                                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": leaving low ping timeout mode");
+                                    Log.d(Config.LOGTAG, account.getLogJid() + ": leaving low ping timeout mode");
                                 }
                             }
                         }
@@ -822,7 +822,7 @@ public class XmppConnectionService extends Service {
                     long discoTimeout = Config.CONNECT_DISCO_TIMEOUT - secondsSinceLastDisco;
                     long timeout = Config.CONNECT_TIMEOUT - secondsSinceLastConnect;
                     if (timeout < 0) {
-                        Log.d(Config.LOGTAG, account.getJid() + ": time out during connect reconnecting (secondsSinceLast=" + secondsSinceLastConnect + ")");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": time out during connect reconnecting (secondsSinceLast=" + secondsSinceLastConnect + ")");
                         account.getXmppConnection().resetAttemptCount(false);
                         reconnectAccount(account, true, interactive);
                     } else if (discoTimeout < 0) {
@@ -847,7 +847,7 @@ public class XmppConnectionService extends Service {
                 Jid jid = conversation.getJid().asBareJid();
                 final String currentHash = CryptoHelper.getFingerprint(jid, androidId);
                 if (currentHash.equals(hash)) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received cloud push notification for MUC " + jid);
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": received cloud push notification for MUC " + jid);
                     return;
                 }
             }
@@ -997,7 +997,7 @@ public class XmppConnectionService extends Service {
     private void dismissErrorNotifications() {
         for (final Account account : this.accounts) {
             if (account.hasErrorStatus()) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": dismissing error notification");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": dismissing error notification");
                 if (account.setShowErrorNotification(false)) {
                     mDatabaseWriterExecutor.execute(() -> databaseBackend.updateAccount(account));
                 }
@@ -1374,7 +1374,7 @@ public class XmppConnectionService extends Service {
         if (QuickConversationsService.isQuicksy() && conversation.getMode() == Conversation.MODE_SINGLE) {
             final Contact contact = conversation.getContact();
             if (!contact.showInRoster() && contact.getOption(Contact.Options.SYNCED_VIA_OTHER)) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": adding " + contact.getJid() + " on sending message");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": adding " + contact.getJid() + " on sending message");
                 createContact(contact, true);
             }
         }
@@ -1531,7 +1531,7 @@ public class XmppConnectionService extends Service {
                 final boolean pending = account.pendingConferenceJoins.contains(conversation);
                 final boolean inProgressJoin = inProgress || pending;
                 if (inProgressJoin) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": holding back message to group. inProgress=" + inProgress + ", pending=" + pending);
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": holding back message to group. inProgress=" + inProgress + ", pending=" + pending);
                 }
                 return inProgressJoin;
             } else {
@@ -1551,10 +1551,10 @@ public class XmppConnectionService extends Service {
     public void fetchRosterFromServer(final Account account) {
         final IqPacket iqPacket = new IqPacket(IqPacket.TYPE.GET);
         if (!"".equals(account.getRosterVersion())) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid()
+            Log.d(Config.LOGTAG, account.getLogJid()
                     + ": fetching roster version " + account.getRosterVersion());
         } else {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": fetching roster");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": fetching roster");
         }
         iqPacket.query(Namespace.ROSTER).setAttribute("ver", account.getRosterVersion());
         sendIqPacket(account, iqPacket, mIqParser);
@@ -1599,7 +1599,7 @@ public class XmppConnectionService extends Service {
             processModifiedBookmark(bookmark, pep, synchronizeWithBookmarks);
         }
         if (pep && synchronizeWithBookmarks) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": " + previousBookmarks.size() + " bookmarks have been removed");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": " + previousBookmarks.size() + " bookmarks have been removed");
             for (Jid jid : previousBookmarks) {
                 processDeletedBookmark(account, jid);
             }
@@ -1610,7 +1610,7 @@ public class XmppConnectionService extends Service {
     public void processDeletedBookmark(Account account, Jid jid) {
         final Conversation conversation = find(account, jid);
         if (conversation != null && conversation.getMucOptions().getError() == MucOptions.Error.DESTROYED) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": archiving destroyed conference (" + conversation.getJid() + ") after receiving pep");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": archiving destroyed conference (" + conversation.getJid() + ") after receiving pep");
             archiveConversation(conversation, false);
         }
     }
@@ -1624,7 +1624,7 @@ public class XmppConnectionService extends Service {
             }
             bookmark.setConversation(conversation);
             if (pep && synchronizeWithBookmarks && !bookmark.autojoin()) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": archiving conference (" + conversation.getJid() + ") after receiving pep");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": archiving conference (" + conversation.getJid() + ") after receiving pep");
                 archiveConversation(conversation, false);
             } else {
                 final MucOptions mucOptions = conversation.getMucOptions();
@@ -1632,7 +1632,7 @@ public class XmppConnectionService extends Service {
                     final String current = mucOptions.getActualNick();
                     final String proposed = mucOptions.getProposedNick();
                     if (current != null && !current.equals(proposed)) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": proposed nick changed after bookmark push " + current + "->" + proposed);
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": proposed nick changed after bookmark push " + current + "->" + proposed);
                         joinMuc(conversation);
                     }
                 }
@@ -1679,7 +1679,7 @@ public class XmppConnectionService extends Service {
     }
 
     private void pushBookmarksPrivateXml(Account account) {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": pushing bookmarks via private xml");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": pushing bookmarks via private xml");
         IqPacket iqPacket = new IqPacket(IqPacket.TYPE.SET);
         Element query = iqPacket.query("jabber:iq:private");
         Element storage = query.addChild("storage", "storage:bookmarks");
@@ -1690,7 +1690,7 @@ public class XmppConnectionService extends Service {
     }
 
     private void pushBookmarksPep(Account account) {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": pushing bookmarks via pep");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": pushing bookmarks via pep");
         Element storage = new Element("storage", "storage:bookmarks");
         for (Bookmark bookmark : account.getBookmarks()) {
             storage.addChild(bookmark);
@@ -1724,11 +1724,11 @@ public class XmppConnectionService extends Service {
 
                     @Override
                     public void onPushFailed() {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": unable to push node configuration (" + node + ")");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": unable to push node configuration (" + node + ")");
                     }
                 });
             } else {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": error publishing bookmarks (retry=" + Boolean.toString(retry) + ") " + response);
+                Log.d(Config.LOGTAG, account.getLogJid() + ": error publishing bookmarks (retry=" + Boolean.toString(retry) + ") " + response);
             }
         });
     }
@@ -2210,10 +2210,10 @@ public class XmppConnectionService extends Service {
     }
 
     public void updateKeyInAccount(final Account account, final String alias) {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": update key in account " + alias);
+        Log.d(Config.LOGTAG, account.getLogJid() + ": update key in account " + alias);
         try {
             X509Certificate[] chain = KeyChain.getCertificateChain(XmppConnectionService.this, alias);
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + " loaded certificate chain");
+            Log.d(Config.LOGTAG, account.getLogJid() + " loaded certificate chain");
             Pair<Jid, String> info = CryptoHelper.extractJidAndName(chain[0]);
             if (info == null) {
                 showErrorToastInUi(R.string.certificate_does_not_contain_jid);
@@ -2292,7 +2292,7 @@ public class XmppConnectionService extends Service {
             }
             final Runnable runnable = () -> {
                 if (!databaseBackend.deleteAccount(account)) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": unable to delete account");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": unable to delete account");
                 }
             };
             mDatabaseWriterExecutor.execute(runnable);
@@ -2574,13 +2574,13 @@ public class XmppConnectionService extends Service {
         final Account account = conversation.getAccount();
         synchronized (account.inProgressConferenceJoins) {
             if (account.inProgressConferenceJoins.contains(conversation)) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": canceling muc self ping because join is already under way");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": canceling muc self ping because join is already under way");
                 return;
             }
         }
         synchronized (account.inProgressConferencePings) {
             if (!account.inProgressConferencePings.add(conversation)) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": canceling muc self ping because ping is already under way");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": canceling muc self ping because ping is already under way");
                 return;
             }
         }
@@ -2657,7 +2657,7 @@ public class XmppConnectionService extends Service {
                     }
 
                     final Jid joinJid = mucOptions.getSelf().getFullJid();
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid().toString() + ": joining conversation " + joinJid.toString());
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": joining conversation " + joinJid.toString());
                     PresencePacket packet = mPresenceGenerator.selfPresence(account, Presence.Status.ONLINE, mucOptions.nonanonymous() || onConferenceJoined != null);
                     packet.setTo(joinJid);
                     Element x = packet.addChild("x", "http://jabber.org/protocol/muc");
@@ -2711,7 +2711,7 @@ public class XmppConnectionService extends Service {
                 @Override
                 public void onConferenceConfigurationFetched(Conversation conversation) {
                     if (conversation.getStatus() == Conversation.STATUS_ARCHIVED) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": conversation (" + conversation.getJid() + ") got archived before IQ result");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": conversation (" + conversation.getJid() + ") got archived before IQ result");
                         return;
                     }
                     join(conversation);
@@ -2720,7 +2720,7 @@ public class XmppConnectionService extends Service {
                 @Override
                 public void onFetchFailed(final Conversation conversation, Element error) {
                     if (conversation.getStatus() == Conversation.STATUS_ARCHIVED) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": conversation (" + conversation.getJid() + ") got archived before IQ result");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": conversation (" + conversation.getJid() + ") got archived before IQ result");
 
                         return;
                     }
@@ -2812,7 +2812,7 @@ public class XmppConnectionService extends Service {
                     }
                 } else {
                     success = false;
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": could not request affiliation " + affiliations[i] + " in " + conversation.getJid().asBareJid());
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": could not request affiliation " + affiliations[i] + " in " + conversation.getJid().asBareJid());
                 }
                 ++i;
                 if (i >= affiliations.length) {
@@ -2824,7 +2824,7 @@ public class XmppConnectionService extends Service {
                             Jid jid = iterator.next();
                             if (!members.contains(jid) && !members.contains(Jid.ofDomain(jid.getDomain()))) {
                                 iterator.remove();
-                                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": removed " + jid + " from crypto targets of " + conversation.getName());
+                                Log.d(Config.LOGTAG, account.getLogJid() + ": removed " + jid + " from crypto targets of " + conversation.getName());
                                 changed = true;
                             }
                         }
@@ -2842,7 +2842,7 @@ public class XmppConnectionService extends Service {
         for (String affiliation : affiliations) {
             sendIqPacket(account, mIqGenerator.queryAffiliation(conversation, affiliation), callback);
         }
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": fetching members for " + conversation.getName());
+        Log.d(Config.LOGTAG, account.getLogJid() + ": fetching members for " + conversation.getName());
     }
 
     public void providePasswordForMuc(Conversation conversation, String password) {
@@ -2902,10 +2902,10 @@ public class XmppConnectionService extends Service {
             final Account account = conversation.getAccount();
             final String defaultNick = MucOptions.defaultNick(account);
             if (TextUtils.isEmpty(bookmarkedNick) && full.getResource().equals(defaultNick)) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": do not overwrite empty bookmark nick with default nick for " + conversation.getJid().asBareJid());
+                Log.d(Config.LOGTAG, account.getLogJid() + ": do not overwrite empty bookmark nick with default nick for " + conversation.getJid().asBareJid());
                 return;
             }
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": persist nick '" + full.getResource() + "' into bookmark for " + conversation.getJid().asBareJid());
+            Log.d(Config.LOGTAG, account.getLogJid() + ": persist nick '" + full.getResource() + "' into bookmark for " + conversation.getJid().asBareJid());
             bookmark.setNick(full.getResource());
             createBookmark(bookmark.getAccount(), bookmark);
         }
@@ -3026,7 +3026,7 @@ public class XmppConnectionService extends Service {
                                          final String name,
                                          final Iterable<Jid> jids,
                                          final UiCallback<Conversation> callback) {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid().toString() + ": creating adhoc conference with " + jids.toString());
+        Log.d(Config.LOGTAG, account.getLogJid() + ": creating adhoc conference with " + jids.toString());
         if (account.getStatus() == Account.State.ONLINE) {
             try {
                 String server = findConferenceServer(account);
@@ -3053,7 +3053,7 @@ public class XmppConnectionService extends Service {
                                 }
                                 for (String resource : account.getSelfContact().getPresences().toResourceArray()) {
                                     Jid other = account.getJid().withResource(resource);
-                                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": sending direct invite to " + other);
+                                    Log.d(Config.LOGTAG, account.getLogJid() + ": sending direct invite to " + other);
                                     directInvite(conversation, other);
                                 }
                                 saveConversationAsBookmark(conversation, name);
@@ -3102,7 +3102,7 @@ public class XmppConnectionService extends Service {
                     final boolean sameBefore = StringUtils.equals(bookmark == null ? null : bookmark.getBookmarkName(), mucOptions.getName());
 
                     if (mucOptions.updateConfiguration(new ServiceDiscoveryResult(packet))) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": muc configuration changed for " + conversation.getJid().asBareJid());
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": muc configuration changed for " + conversation.getJid().asBareJid());
                         updateConversation(conversation);
                     }
 
@@ -3120,7 +3120,7 @@ public class XmppConnectionService extends Service {
 
                     updateConversationUi();
                 } else if (packet.getType() == IqPacket.TYPE.TIMEOUT) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received timeout waiting for conference configuration fetch");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": received timeout waiting for conference configuration fetch");
                 } else {
                     if (callback != null) {
                         callback.onFetchFailed(conversation, packet.getError());
@@ -3150,7 +3150,7 @@ public class XmppConnectionService extends Service {
                             @Override
                             public void onIqPacketReceived(Account account, IqPacket packet) {
                                 if (packet.getType() == IqPacket.TYPE.RESULT && callback != null) {
-                                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": successfully changed node configuration for node " + node);
+                                    Log.d(Config.LOGTAG, account.getLogJid() + ": successfully changed node configuration for node " + node);
                                     callback.onPushSucceeded();
                                 } else if (packet.getType() == IqPacket.TYPE.ERROR && callback != null) {
                                     callback.onPushFailed();
@@ -3247,7 +3247,7 @@ public class XmppConnectionService extends Service {
         Log.d(Config.LOGTAG, request.toString());
         sendIqPacket(conference.getAccount(), request, (account, packet) -> {
             if (packet.getType() != IqPacket.TYPE.RESULT) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + " unable to change role of " + nick);
+                Log.d(Config.LOGTAG, account.getLogJid() + " unable to change role of " + nick);
             }
         });
     }
@@ -3436,7 +3436,7 @@ public class XmppConnectionService extends Service {
     }
 
     public void publishAvatar(Account account, final Avatar avatar, final Bundle options, final boolean retry, final OnAvatarPublication callback) {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": publishing avatar. options=" + options);
+        Log.d(Config.LOGTAG, account.getLogJid() + ": publishing avatar. options=" + options);
         IqPacket packet = this.mIqGenerator.publishAvatar(avatar, options);
         this.sendIqPacket(account, packet, new OnIqPacketReceived() {
 
@@ -3448,19 +3448,19 @@ public class XmppConnectionService extends Service {
                     pushNodeConfiguration(account, "urn:xmpp:avatar:data", options, new OnConfigurationPushed() {
                         @Override
                         public void onPushSucceeded() {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": changed node configuration for avatar node");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": changed node configuration for avatar node");
                             publishAvatar(account, avatar, options, false, callback);
                         }
 
                         @Override
                         public void onPushFailed() {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": unable to change node configuration for avatar node");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": unable to change node configuration for avatar node");
                             publishAvatar(account, avatar, null, false, callback);
                         }
                     });
                 } else {
                     Element error = result.findChild("error");
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": server rejected avatar " + (avatar.size / 1024) + "KiB " + (error != null ? error.toString() : ""));
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": server rejected avatar " + (avatar.size / 1024) + "KiB " + (error != null ? error.toString() : ""));
                     if (callback != null) {
                         callback.onAvatarPublicationFailed(R.string.error_publish_avatar_server_reject);
                     }
@@ -3480,7 +3480,7 @@ public class XmppConnectionService extends Service {
                         databaseBackend.updateAccount(account);
                         notifyAccountAvatarHasChanged(account);
                     }
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": published avatar " + (avatar.size / 1024) + "KiB");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": published avatar " + (avatar.size / 1024) + "KiB");
                     if (callback != null) {
                         callback.onAvatarPublicationSucceeded();
                     }
@@ -3488,13 +3488,13 @@ public class XmppConnectionService extends Service {
                     pushNodeConfiguration(account, "urn:xmpp:avatar:metadata", options, new OnConfigurationPushed() {
                         @Override
                         public void onPushSucceeded() {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": changed node configuration for avatar meta data node");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": changed node configuration for avatar meta data node");
                             publishAvatarMetadata(account, avatar, options, false, callback);
                         }
 
                         @Override
                         public void onPushFailed() {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": unable to change node configuration for avatar meta data node");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": unable to change node configuration for avatar meta data node");
                             publishAvatarMetadata(account, avatar, null, false, callback);
                         }
                     });
@@ -3509,7 +3509,7 @@ public class XmppConnectionService extends Service {
 
     public void republishAvatarIfNeeded(Account account) {
         if (account.getAxolotlService().isPepBroken()) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": skipping republication of avatar because pep is broken");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": skipping republication of avatar because pep is broken");
             return;
         }
         IqPacket packet = this.mIqGenerator.retrieveAvatarMetaData(null);
@@ -3540,7 +3540,7 @@ public class XmppConnectionService extends Service {
                     if (serverAvatar == null && account.getAvatar() != null) {
                         Avatar avatar = fileBackend.getStoredPepAvatar(account.getAvatar());
                         if (avatar != null) {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": avatar on server was null. republishing");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": avatar on server was null. republishing");
                             publishAvatar(account, fileBackend.getStoredPepAvatar(account.getAvatar()), null);
                         } else {
                             Log.e(Config.LOGTAG, account.getJid().asBareJid() + ": error rereading avatar");
@@ -3572,7 +3572,7 @@ public class XmppConnectionService extends Service {
             } else if (avatar.origin == Avatar.Origin.PEP) {
                 mOmittedPepAvatarFetches.add(KEY);
             } else {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": already fetching " + avatar.origin + " avatar for " + avatar.owner);
+                Log.d(Config.LOGTAG, account.getLogJid() + ": already fetching " + avatar.origin + " avatar for " + avatar.owner);
             }
         }
     }
@@ -3648,11 +3648,11 @@ public class XmppConnectionService extends Service {
                     if (image != null) {
                         avatar.image = image;
                         if (getFileBackend().save(avatar)) {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid()
+                            Log.d(Config.LOGTAG, account.getLogJid()
                                     + ": successfully fetched vCard avatar for " + avatar.owner + " omittedPep=" + previouslyOmittedPepFetch);
                             if (avatar.owner.isBareJid()) {
                                 if (account.getJid().asBareJid().equals(avatar.owner) && account.getAvatar() == null) {
-                                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": had no avatar. replacing with vcard");
+                                    Log.d(Config.LOGTAG, account.getLogJid() + ": had no avatar. replacing with vcard");
                                     account.setAvatar(avatar.getFilename());
                                     databaseBackend.updateAccount(account);
                                     getAvatarService().clear(account);
@@ -3730,7 +3730,7 @@ public class XmppConnectionService extends Service {
     public void notifyAccountAvatarHasChanged(final Account account) {
         final XmppConnection connection = account.getXmppConnection();
         if (connection != null && connection.getFeatures().bookmarksConversion()) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": avatar changed. resending presence to online group chats");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": avatar changed. resending presence to online group chats");
             for (Conversation conversation : conversations) {
                 if (conversation.getAccount() == account && conversation.getMode() == Conversational.MODE_MULTI) {
                     final MucOptions mucOptions = conversation.getMucOptions();
@@ -4235,7 +4235,7 @@ public class XmppConnectionService extends Service {
     }
 
     private void sendOfflinePresence(final Account account) {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": sending offline presence");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": sending offline presence");
         sendPresencePacket(account, mPresenceGenerator.sendOfflinePresence(account));
     }
 
@@ -4376,7 +4376,7 @@ public class XmppConnectionService extends Service {
                     this.conversations.remove(conversation);
                     markRead(conversation);
                     conversation.setStatus(Conversation.STATUS_ARCHIVED);
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": archiving conversation " + conversation.getJid().asBareJid() + " because jid was blocked");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": archiving conversation " + conversation.getJid().asBareJid() + " because jid was blocked");
                     updateConversation(conversation);
                     removed = true;
                 }
@@ -4445,7 +4445,7 @@ public class XmppConnectionService extends Service {
                 if (node != null && ver != null) {
                     query.setAttribute("node", node + "#" + ver);
                 }
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": making disco request for " + key.second + " to " + jid);
+                Log.d(Config.LOGTAG, account.getLogJid() + ": making disco request for " + key.second + " to " + jid);
                 sendIqPacket(account, request, (a, response) -> {
                     if (response.getType() == IqPacket.TYPE.RESULT) {
                         ServiceDiscoveryResult discoveryResult = new ServiceDiscoveryResult(response);

--- a/src/main/java/eu/siacs/conversations/utils/SSLSocketHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/SSLSocketHelper.java
@@ -98,6 +98,6 @@ public class SSLSocketHelper {
 
     public static void log(Account account, SSLSocket socket) {
         SSLSession session = socket.getSession();
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": protocol=" + session.getProtocol() + " cipher=" + session.getCipherSuite());
+        Log.d(Config.LOGTAG, account.getLogJid() + ": protocol=" + session.getProtocol() + " cipher=" + session.getCipherSuite());
     }
 }

--- a/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleConnection.java
@@ -109,9 +109,9 @@ public class JingleConnection implements Transferable {
         public void onFileTransmitted(DownloadableFile file) {
             if (responding()) {
                 if (expectedHash.length > 0 && !Arrays.equals(expectedHash, file.getSha1Sum())) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": hashes did not match");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": hashes did not match");
                 }
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": file transmitted(). we are responding");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": file transmitted(). we are responding");
                 sendSuccess();
                 mXmppConnectionService.getFileBackend().updateFileParams(message);
                 mXmppConnectionService.databaseBackend.createMessage(message);
@@ -160,7 +160,7 @@ public class JingleConnection implements Transferable {
 
         @Override
         public void established() {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": ibb transport connected. sending file");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": ibb transport connected. sending file");
             mJingleStatus = JINGLE_STATUS_TRANSMITTING;
             JingleConnection.this.transport.send(file, onFileTransmissionStatusChanged);
         }
@@ -180,7 +180,7 @@ public class JingleConnection implements Transferable {
 
         @Override
         public void failed() {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": proxy activation failed");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": proxy activation failed");
             proxyActivationFailed = true;
             if (initiating()) {
                 sendFallbackToIbb();
@@ -459,7 +459,7 @@ public class JingleConnection implements Transferable {
             if (encrypted == null) {
                 final Element security = content.findChild("security", Namespace.JINGLE_ENCRYPTED_TRANSPORT);
                 if (security != null && AxolotlService.PEP_PREFIX.equals(security.getAttribute("type"))) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received jingle file offer with JET");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": received jingle file offer with JET");
                     encrypted = security.findChild("encrypted", AxolotlService.PEP_PREFIX);
                     remoteIsUsingJet = true;
                 }
@@ -561,7 +561,7 @@ public class JingleConnection implements Transferable {
                 this.file.setExpectedSize(file.getSize() + (this.remoteSupportsOmemoJet ? 0 : 16));
                 final Element file = content.setFileOffer(this.file, false, this.ftVersion);
                 if (remoteSupportsOmemoJet) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": remote announced support for JET");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": remote announced support for JET");
                     final Element security = new Element("security", Namespace.JINGLE_ENCRYPTED_TRANSPORT);
                     security.setAttribute("name", this.contentName);
                     security.setAttribute("cipher", JET_OMEMO_CIPHER);
@@ -585,7 +585,7 @@ public class JingleConnection implements Transferable {
             content.setTransportId(this.transportId);
             if (this.initialTransport == Transport.IBB) {
                 content.ibbTransport().setAttribute("block-size", Integer.toString(this.ibbBlockSize));
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": sending IBB offer");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": sending IBB offer");
             } else {
                 final List<Element> candidates = getCandidatesAsElements();
                 Log.d(Config.LOGTAG, String.format("%s: sending S5B offer with %d candidates", account.getJid().asBareJid(), candidates.size()));
@@ -594,7 +594,7 @@ public class JingleConnection implements Transferable {
             packet.setContent(content);
             this.sendJinglePacket(packet, (account, response) -> {
                 if (response.getType() == IqPacket.TYPE.RESULT) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": other party received offer");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": other party received offer");
                     if (mJingleStatus == JINGLE_STATUS_OFFERED) {
                         mJingleStatus = JINGLE_STATUS_INITIATED;
                         mXmppConnectionService.markMessage(message, Message.STATUS_OFFERED);
@@ -709,12 +709,12 @@ public class JingleConnection implements Transferable {
 
     private void receiveAccept(JinglePacket packet) {
         if (responding()) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received out of order session-accept (we were responding)");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received out of order session-accept (we were responding)");
             respondToIqWithOutOfOrder(packet);
             return;
         }
         if (this.mJingleStatus != JINGLE_STATUS_INITIATED) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received out of order session-accept");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received out of order session-accept");
             respondToIqWithOutOfOrder(packet);
             return;
         }
@@ -734,7 +734,7 @@ public class JingleConnection implements Transferable {
                         this.ibbBlockSize = bs;
                     }
                 } catch (Exception e) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": unable to parse block size in session-accept");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": unable to parse block size in session-accept");
                 }
             }
             respondToIq(packet, true);
@@ -769,7 +769,7 @@ public class JingleConnection implements Transferable {
                 respondToIq(packet, true);
                 onProxyActivated.failed();
             } else if (content.socks5transport().hasChild("candidate-error")) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received candidate error");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": received candidate error");
                 respondToIq(packet, true);
                 this.receivedCandidate = true;
                 if (mJingleStatus == JINGLE_STATUS_ACCEPTED && this.sentCandidate) {
@@ -808,20 +808,20 @@ public class JingleConnection implements Transferable {
         final JingleSocks5Transport connection = chooseConnection();
         this.transport = connection;
         if (connection == null) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": could not find suitable candidate");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": could not find suitable candidate");
             this.disconnectSocks5Connections();
             if (initiating()) {
                 this.sendFallbackToIbb();
             }
         } else {
             final JingleCandidate candidate = connection.getCandidate();
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": elected candidate " + candidate.getHost() + ":" + candidate.getPort());
+            Log.d(Config.LOGTAG, account.getLogJid() + ": elected candidate " + candidate.getHost() + ":" + candidate.getPort());
             this.mJingleStatus = JINGLE_STATUS_TRANSMITTING;
             if (connection.needsActivation()) {
                 if (connection.getCandidate().isOurs()) {
                     final String sid;
                     if (ftVersion == Content.Version.FT_3) {
-                        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": use session ID instead of transport ID to activate proxy");
+                        Log.d(Config.LOGTAG, account.getLogJid() + ": use session ID instead of transport ID to activate proxy");
                         sid = getSessionId();
                     } else {
                         sid = getTransportId();
@@ -837,7 +837,7 @@ public class JingleConnection implements Transferable {
                             .setContent(this.getCounterPart().toString());
                     mXmppConnectionService.sendIqPacket(account, activation, (account, response) -> {
                         if (response.getType() != IqPacket.TYPE.RESULT) {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": " + response.toString());
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": " + response.toString());
                             sendProxyError();
                             onProxyActivated.failed();
                         } else {
@@ -909,7 +909,7 @@ public class JingleConnection implements Transferable {
     }
 
     private void sendFallbackToIbb() {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": sending fallback to ibb");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": sending fallback to ibb");
         JinglePacket packet = this.bootstrapPacket("transport-replace");
         Content content = new Content(this.contentCreator, this.contentName);
         this.transportId = this.mJingleConnectionManager.nextRandomId();
@@ -923,18 +923,18 @@ public class JingleConnection implements Transferable {
 
     private void receiveFallbackToIbb(JinglePacket packet) {
         if (initiating()) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received out of order transport-replace (we were initiating)");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received out of order transport-replace (we were initiating)");
             respondToIqWithOutOfOrder(packet);
             return;
         }
         final boolean validState = mJingleStatus == JINGLE_STATUS_ACCEPTED || (proxyActivationFailed && mJingleStatus == JINGLE_STATUS_TRANSMITTING);
         if (!validState) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received out of order transport-replace");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received out of order transport-replace");
             respondToIqWithOutOfOrder(packet);
             return;
         }
         this.proxyActivationFailed = false; //fallback received; now we no longer need to accept another one;
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": receiving fallback to ibb");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": receiving fallback to ibb");
         final String receivedBlockSize = packet.getJingleContent().ibbTransport().getAttribute("block-size");
         if (receivedBlockSize != null) {
             try {
@@ -943,7 +943,7 @@ public class JingleConnection implements Transferable {
                     this.ibbBlockSize = bs;
                 }
             } catch (NumberFormatException e) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": unable to parse block size in transport-replace");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": unable to parse block size in transport-replace");
             }
         }
         this.transportId = packet.getJingleContent().getTransportId();
@@ -961,7 +961,7 @@ public class JingleConnection implements Transferable {
         if (initiating()) {
             this.sendJinglePacket(answer, (account, response) -> {
                 if (response.getType() == IqPacket.TYPE.RESULT) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + " recipient ACKed our transport-accept. creating ibb");
+                    Log.d(Config.LOGTAG, account.getLogJid() + " recipient ACKed our transport-accept. creating ibb");
                     transport.connect(onIbbTransportConnected);
                 }
             });
@@ -973,13 +973,13 @@ public class JingleConnection implements Transferable {
 
     private void receiveTransportAccept(JinglePacket packet) {
         if (responding()) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received out of order transport-accept (we were responding)");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received out of order transport-accept (we were responding)");
             respondToIqWithOutOfOrder(packet);
             return;
         }
         final boolean validState = mJingleStatus == JINGLE_STATUS_ACCEPTED || (proxyActivationFailed && mJingleStatus == JINGLE_STATUS_TRANSMITTING);
         if (!validState) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received out of order transport-accept");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received out of order transport-accept");
             respondToIqWithOutOfOrder(packet);
             return;
         }
@@ -995,7 +995,7 @@ public class JingleConnection implements Transferable {
                         this.ibbBlockSize = bs;
                     }
                 } catch (NumberFormatException e) {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": unable to parse block size in transport-accept");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": unable to parse block size in transport-accept");
                 }
             }
             this.transport = new JingleInBandTransport(this, this.transportId, this.ibbBlockSize);
@@ -1009,7 +1009,7 @@ public class JingleConnection implements Transferable {
                 this.transport.connect(onIbbTransportConnected);
             }
         } else {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received invalid transport-accept");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received invalid transport-accept");
             respondToIq(packet, false);
         }
     }
@@ -1025,7 +1025,7 @@ public class JingleConnection implements Transferable {
             this.message.setTransferable(null);
             this.mJingleConnectionManager.finishConnection(this);
         } else {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received session-terminate/success while responding");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": received session-terminate/success while responding");
         }
     }
 
@@ -1168,7 +1168,7 @@ public class JingleConnection implements Transferable {
     }
 
     private void sendCandidateError() {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": sending candidate error");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": sending candidate error");
         JinglePacket packet = bootstrapPacket("transport-info");
         Content content = new Content(this.contentCreator, this.contentName);
         content.setTransportId(this.transportId);

--- a/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleInBandTransport.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleInBandTransport.java
@@ -69,7 +69,7 @@ public class JingleInBandTransport extends JingleTransport {
     }
 
     private void sendClose() {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": sending ibb close");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": sending ibb close");
         IqPacket iq = new IqPacket(IqPacket.TYPE.SET);
         iq.setTo(this.counterpart);
         Element close = iq.addChild("close", "http://jabber.org/protocol/ibb");
@@ -103,13 +103,13 @@ public class JingleInBandTransport extends JingleTransport {
             digest.reset();
             this.fileOutputStream = connection.getFileOutputStream();
             if (this.fileOutputStream == null) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": could not create output stream");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": could not create output stream");
                 callback.onFileTransferAborted();
                 return;
             }
             this.remainingSize = this.fileSize = file.getExpectedSize();
         } catch (final NoSuchAlgorithmException | IOException e) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + " " + e.getMessage());
+            Log.d(Config.LOGTAG, account.getLogJid() + " " + e.getMessage());
             callback.onFileTransferAborted();
         }
     }
@@ -125,7 +125,7 @@ public class JingleInBandTransport extends JingleTransport {
             this.digest.reset();
             fileInputStream = connection.getFileInputStream();
             if (fileInputStream == null) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": could no create input stream");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": could no create input stream");
                 callback.onFileTransferAborted();
                 return;
             }
@@ -135,7 +135,7 @@ public class JingleInBandTransport extends JingleTransport {
             }
         } catch (Exception e) {
             callback.onFileTransferAborted();
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": " + e.getMessage());
+            Log.d(Config.LOGTAG, account.getLogJid() + ": " + e.getMessage());
         }
     }
 
@@ -153,7 +153,7 @@ public class JingleInBandTransport extends JingleTransport {
             if (count == -1) {
                 sendClose();
                 file.setSha1Sum(digest.digest());
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": sendNextBlock() count was -1");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": sendNextBlock() count was -1");
                 this.onFileTransmissionStatusChanged.onFileTransmitted(file);
                 fileInputStream.close();
                 return;
@@ -184,7 +184,7 @@ public class JingleInBandTransport extends JingleTransport {
                 fileInputStream.close();
             }
         } catch (IOException e) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": io exception during sendNextBlock() " + e.getMessage());
+            Log.d(Config.LOGTAG, account.getLogJid() + ": io exception during sendNextBlock() " + e.getMessage());
             FileBackend.close(fileInputStream);
             this.onFileTransmissionStatusChanged.onFileTransferAborted();
         }
@@ -200,12 +200,12 @@ public class JingleInBandTransport extends JingleTransport {
             this.fileOutputStream.write(buffer);
             this.digest.update(buffer);
             if (this.remainingSize <= 0) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received last block. waiting for close");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": received last block. waiting for close");
             } else {
                 connection.updateProgress((int) ((((double) (this.fileSize - this.remainingSize)) / this.fileSize) * 100));
             }
         } catch (Exception e) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": " + e.getMessage());
+            Log.d(Config.LOGTAG, account.getLogJid() + ": " + e.getMessage());
             FileBackend.close(fileOutputStream);
             this.onFileTransmissionStatusChanged.onFileTransferAborted();
         }
@@ -218,7 +218,7 @@ public class JingleInBandTransport extends JingleTransport {
             fileOutputStream.close();
             this.onFileTransmissionStatusChanged.onFileTransmitted(file);
         } catch (Exception e) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": " + e.getMessage());
+            Log.d(Config.LOGTAG, account.getLogJid() + ": " + e.getMessage());
             FileBackend.close(fileOutputStream);
             this.onFileTransmissionStatusChanged.onFileTransferAborted();
         }
@@ -245,10 +245,10 @@ public class JingleInBandTransport extends JingleTransport {
             this.account.getXmppConnection().sendIqPacket(
                     packet.generateResponse(IqPacket.TYPE.RESULT), null);
             if (this.remainingSize <= 0) {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received ibb close. done");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": received ibb close. done");
                 done();
             } else {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": received ibb close with " + this.remainingSize + " remaining");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": received ibb close with " + this.remainingSize + " remaining");
                 FileBackend.close(fileOutputStream);
                 this.onFileTransmissionStatusChanged.onFileTransferAborted();
             }

--- a/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleSocks5Transport.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleSocks5Transport.java
@@ -214,7 +214,7 @@ public class JingleSocks5Transport extends JingleTransport {
                 }
             } catch (Exception e) {
                 final Account account = connection.getAccount();
-                Log.d(Config.LOGTAG, account.getJid().asBareJid()+": failed sending file after "+transmitted+"/"+file.getExpectedSize()+" ("+ socket.getInetAddress()+":"+socket.getPort()+")", e);
+                Log.d(Config.LOGTAG, account.getLogJid()+": failed sending file after "+transmitted+"/"+file.getExpectedSize()+" ("+ socket.getInetAddress()+":"+socket.getPort()+")", e);
                 callback.onFileTransferAborted();
             } finally {
                 FileBackend.close(fileInputStream);

--- a/src/playstore/java/eu/siacs/conversations/services/PushManagementService.java
+++ b/src/playstore/java/eu/siacs/conversations/services/PushManagementService.java
@@ -39,7 +39,7 @@ public class PushManagementService {
     }
 
     void registerPushTokenOnServer(final Account account) {
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": has push support");
+        Log.d(Config.LOGTAG, account.getLogJid() + ": has push support");
         retrieveFcmInstanceToken(token -> {
             final String androidId = PhoneHelper.getAndroidId(mXmppConnectionService);
             final IqPacket packet = mXmppConnectionService.getIqGenerator().pushTokenToAppServer(getAppServer(), token, androidId);

--- a/src/quicksy/java/eu/siacs/conversations/services/QuickConversationsService.java
+++ b/src/quicksy/java/eu/siacs/conversations/services/QuickConversationsService.java
@@ -217,7 +217,7 @@ public class QuickConversationsService extends AbstractQuickConversationsService
                         try {
                             awaitingAccountStateChange.await(5, TimeUnit.SECONDS);
                         } catch (InterruptedException e) {
-                            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": timer expired while waiting for account to connect");
+                            Log.d(Config.LOGTAG, account.getLogJid() + ": timer expired while waiting for account to connect");
                         }
                         synchronized (mOnVerification) {
                             for (OnVerification onVerification : mOnVerification) {
@@ -355,14 +355,14 @@ public class QuickConversationsService extends AbstractQuickConversationsService
 
     private boolean considerSync(Account account, final Map<String, PhoneNumberContact> contacts, final boolean forced) {
         final int hash = contacts.keySet().hashCode();
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": consider sync of " + hash);
+        Log.d(Config.LOGTAG, account.getLogJid() + ": consider sync of " + hash);
         if (!mLastSyncAttempt.retry(hash) && !forced) {
-            Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": do not attempt sync");
+            Log.d(Config.LOGTAG, account.getLogJid() + ": do not attempt sync");
             return false;
         }
         mRunningSyncJobs.incrementAndGet();
         final Jid syncServer = Jid.of(API_DOMAIN);
-        Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": sending phone list to " + syncServer);
+        Log.d(Config.LOGTAG, account.getLogJid() + ": sending phone list to " + syncServer);
         List<Element> entries = new ArrayList<>();
         for (PhoneNumberContact c : contacts.values()) {
             entries.add(new Element("entry").setAttribute("number", c.getPhoneNumber()));
@@ -400,12 +400,12 @@ public class QuickConversationsService extends AbstractQuickConversationsService
                         }
                     }
                 } else {
-                    Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": phone number contact list remains unchanged");
+                    Log.d(Config.LOGTAG, account.getLogJid() + ": phone number contact list remains unchanged");
                 }
             } else if (response.getType() == IqPacket.TYPE.TIMEOUT) {
                 mLastSyncAttempt = Attempt.NULL;
             } else {
-                Log.d(Config.LOGTAG, account.getJid().asBareJid() + ": failed to sync contact list with api server");
+                Log.d(Config.LOGTAG, account.getLogJid() + ": failed to sync contact list with api server");
             }
             mRunningSyncJobs.decrementAndGet();
             service.syncRoster(account);


### PR DESCRIPTION
Implementation of issue #1588 :
JID test@example.org will be replaced by t***@ e********** in logs.

closes #1588, closes #1150